### PR TITLE
Improve/performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "concurrently": "^8.2.2",
         "eslint": "^9.5.0",
         "jsdoc-to-markdown": "^8.0.1",
-        "rollup": "^4.18.0",
+        "rollup": "^4.23.0",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-glslify": "^1.3.1",
         "rollup-plugin-license": "^3.5.2",

--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -439,10 +439,6 @@ class gltfRenderer
         }
 
         let fragDefines = material.getDefines(state.renderingParameters).concat(vertDefines);
-        if (renderpassConfiguration.linearOutput)
-        {
-            fragDefines.push("LINEAR_OUTPUT 1");
-        }
 
         // POINTS, LINES, LINE_LOOP, LINE_STRIP
         if (primitive.mode < 4) {

--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -84,6 +84,10 @@ class gltfRenderer
         this.lightFill.direction = vec3.create();
         vec3.transformQuat(this.lightKey.direction, [0, 0, -1], quatKey);
         vec3.transformQuat(this.lightFill.direction, [0, 0, -1], quatFill);
+
+        this.previousPrimitive = undefined;
+        this.previousMaterial = undefined;
+        this.firstDraw = true;
     }
 
     /////////////////////////////////////////////////////////////////////
@@ -237,6 +241,9 @@ class gltfRenderer
             this.prepareScene(state, scene);
             this.preparedScene = scene;
         }
+        this.previousMaterial = undefined;
+        this.previousPrimitive = undefined;
+        this.firstDraw = true;
 
         let currentCamera = undefined;
 
@@ -395,6 +402,11 @@ class gltfRenderer
             material = state.gltf.materials[primitive.material];
         }
 
+        const sameMaterial = this.previousMaterial === material;
+        const samePrimitive = this.previousPrimitive === primitive;
+        this.previousMaterial = material;
+        this.previousPrimitive = primitive;
+
         //select shader permutation, compile and link program.
 
         let vertDefines = [];
@@ -406,12 +418,15 @@ class gltfRenderer
         {
             fragDefines.push("LINEAR_OUTPUT 1");
         }
-        // POINTS, LINES, LINE_LOOP, LINE_STRIP
-        if (primitive.mode < 4) {
-            fragDefines.push("NOT_TRIANGLE 1");
-            if (primitive.attributes?.NORMAL !== undefined && primitive.attributes?.TANGENT === undefined) {
-                //Points or Lines with NORMAL but without TANGENT attributes SHOULD be rendered with standard lighting but ignoring any normal textures on the material.
-                fragDefines = fragDefines.filter(e => e !== "HAS_NORMAL_MAP 1" && e !== "HAS_CLEARCOAT_NORMAL_MAP 1");
+
+        if (!samePrimitive) {
+            // POINTS, LINES, LINE_LOOP, LINE_STRIP
+            if (primitive.mode < 4) {
+                fragDefines.push("NOT_TRIANGLE 1");
+                if (primitive.attributes?.NORMAL !== undefined && primitive.attributes?.TANGENT === undefined) {
+                    //Points or Lines with NORMAL but without TANGENT attributes SHOULD be rendered with standard lighting but ignoring any normal textures on the material.
+                    fragDefines = fragDefines.filter(e => e !== "HAS_NORMAL_MAP 1" && e !== "HAS_CLEARCOAT_NORMAL_MAP 1");
+                }
             }
         }
         this.pushFragParameterDefines(fragDefines, state);
@@ -440,8 +455,10 @@ class gltfRenderer
         this.shader.updateUniform("u_ViewProjectionMatrix", viewProjectionMatrix);
         this.shader.updateUniform("u_ModelMatrix", node.worldTransform);
         this.shader.updateUniform("u_NormalMatrix", node.normalMatrix, false);
-        this.shader.updateUniform("u_Exposure", state.renderingParameters.exposure, false);
-        this.shader.updateUniform("u_Camera", this.currentCameraPosition, false);
+        if (this.firstDraw) {
+            this.shader.updateUniform("u_Exposure", state.renderingParameters.exposure, false);
+            this.shader.updateUniform("u_Camera", this.currentCameraPosition, false);
+        }
 
         this.updateAnimationUniforms(state, node, primitive);
 
@@ -453,25 +470,26 @@ class gltfRenderer
         {
             this.webGl.context.frontFace(GL.CCW);
         }
-
-        if (material.doubleSided)
-        {
-            this.webGl.context.disable(GL.CULL_FACE);
-        }
-        else
-        {
-            this.webGl.context.enable(GL.CULL_FACE);
-        }
-
-        if (material.alphaMode === 'BLEND')
-        {
-            this.webGl.context.enable(GL.BLEND);
-            this.webGl.context.blendFuncSeparate(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ONE, GL.ONE_MINUS_SRC_ALPHA);
-            this.webGl.context.blendEquation(GL.FUNC_ADD);
-        }
-        else
-        {
-            this.webGl.context.disable(GL.BLEND);
+        if (!sameMaterial) {
+            if (material.doubleSided)
+            {
+                this.webGl.context.disable(GL.CULL_FACE);
+            }
+            else
+            {
+                this.webGl.context.enable(GL.CULL_FACE);
+            }
+        
+            if (material.alphaMode === 'BLEND')
+            {
+                this.webGl.context.enable(GL.BLEND);
+                this.webGl.context.blendFuncSeparate(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA, GL.ONE, GL.ONE_MINUS_SRC_ALPHA);
+                this.webGl.context.blendEquation(GL.FUNC_ADD);
+            }
+            else
+            {
+                this.webGl.context.disable(GL.BLEND);
+            }
         }
 
         const drawIndexed = primitive.indices !== undefined;
@@ -501,83 +519,84 @@ class gltfRenderer
         }
 
         // Update material uniforms
-
-        material.updateTextureTransforms(this.shader);
-
-        this.shader.updateUniform("u_EmissiveFactor", jsToGl(material.emissiveFactor));
-        this.shader.updateUniform("u_AlphaCutoff", material.alphaCutoff);
-
-        this.shader.updateUniform("u_NormalScale", material.normalTexture?.scale);
-        this.shader.updateUniform("u_NormalUVSet", material.normalTexture?.texCoord);
-
-        this.shader.updateUniform("u_OcclusionStrength", material.occlusionTexture?.strength);
-        this.shader.updateUniform("u_OcclusionUVSet", material.occlusionTexture?.texCoord);
-
-        this.shader.updateUniform("u_EmissiveUVSet", material.emissiveTexture?.texCoord);
-
-        this.shader.updateUniform("u_BaseColorUVSet", material.pbrMetallicRoughness?.baseColorTexture?.texCoord);
+        if (!sameMaterial) {
+            material.updateTextureTransforms(this.shader);
+    
+            this.shader.updateUniform("u_EmissiveFactor", jsToGl(material.emissiveFactor));
+            this.shader.updateUniform("u_AlphaCutoff", material.alphaCutoff);
+    
+            this.shader.updateUniform("u_NormalScale", material.normalTexture?.scale);
+            this.shader.updateUniform("u_NormalUVSet", material.normalTexture?.texCoord);
+    
+            this.shader.updateUniform("u_OcclusionStrength", material.occlusionTexture?.strength);
+            this.shader.updateUniform("u_OcclusionUVSet", material.occlusionTexture?.texCoord);
+    
+            this.shader.updateUniform("u_EmissiveUVSet", material.emissiveTexture?.texCoord);
+    
+            this.shader.updateUniform("u_BaseColorUVSet", material.pbrMetallicRoughness?.baseColorTexture?.texCoord);
+            
+            this.shader.updateUniform("u_MetallicRoughnessUVSet", material.pbrMetallicRoughness?.metallicRoughnessTexture?.texCoord);
+            this.shader.updateUniform("u_MetallicFactor", material.pbrMetallicRoughness?.metallicFactor);
+            this.shader.updateUniform("u_RoughnessFactor", material.pbrMetallicRoughness?.roughnessFactor);
+            this.shader.updateUniform("u_BaseColorFactor", jsToGl(material.pbrMetallicRoughness?.baseColorFactor));
+    
+            this.shader.updateUniform("u_AnisotropyUVSet", material.extensions?.KHR_materials_anisotropy?.anisotropyTexture?.texCoord);
+    
+            const factor = material.extensions?.KHR_materials_anisotropy?.anisotropyStrength;
+            const rotation = material.extensions?.KHR_materials_anisotropy?.anisotropyRotation;
+            const anisotropy =  vec3.fromValues(Math.cos(rotation ?? 0), Math.sin(rotation ?? 0), factor ?? 0.0);
+            this.shader.updateUniform("u_Anisotropy", anisotropy);
+    
+            this.shader.updateUniform("u_ClearcoatFactor", material.extensions?.KHR_materials_clearcoat?.clearcoatFactor);
+            this.shader.updateUniform("u_ClearcoatRoughnessFactor", material.extensions?.KHR_materials_clearcoat?.clearcoatRoughnessFactor);
+            this.shader.updateUniform("u_ClearcoatUVSet", material.extensions?.KHR_materials_clearcoat?.clearcoatTexture?.texCoord);
+            this.shader.updateUniform("u_ClearcoatRoughnessUVSet", material.extensions?.KHR_materials_clearcoat?.clearcoatRoughnessTexture?.texCoord);
+            this.shader.updateUniform("u_ClearcoatNormalUVSet", material.extensions?.KHR_materials_clearcoat?.clearcoatNormalTexture?.texCoord);
+            this.shader.updateUniform("u_ClearcoatNormalScale", material.extensions?.KHR_materials_clearcoat?.clearcoatNormalTexture?.scale);
+    
+            this.shader.updateUniform("u_Dispersion", material.extensions?.KHR_materials_dispersion?.dispersion);
+    
+            this.shader.updateUniform("u_EmissiveStrength", material.extensions?.KHR_materials_emissive_strength?.emissiveStrength);
+    
+            this.shader.updateUniform("u_Ior", material.extensions?.KHR_materials_ior?.ior);
+    
+            this.shader.updateUniform("u_IridescenceFactor", material.extensions?.KHR_materials_iridescence?.iridescenceFactor);
+            this.shader.updateUniform("u_IridescenceIor", material.extensions?.KHR_materials_iridescence?.iridescenceIor);
+            this.shader.updateUniform("u_IridescenceThicknessMaximum", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessMaximum);
+            this.shader.updateUniform("u_IridescenceUVSet", material.extensions?.KHR_materials_iridescence?.iridescenceTexture?.texCoord);
+            this.shader.updateUniform("u_IridescenceThicknessUVSet", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessTexture?.texCoord);
+            this.shader.updateUniform("u_IridescenceThicknessMinimum", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessMinimum);
+    
+            this.shader.updateUniform("u_SheenRoughnessFactor", material.extensions?.KHR_materials_sheen?.sheenRoughnessFactor);
+            this.shader.updateUniform("u_SheenColorFactor", jsToGl(material.extensions?.KHR_materials_sheen?.sheenColorFactor));
+            this.shader.updateUniform("u_SheenRoughnessUVSet", material.extensions?.KHR_materials_sheen?.sheenRoughnessTexture?.texCoord);
+            this.shader.updateUniform("u_SheenColorUVSet", material.extensions?.KHR_materials_sheen?.sheenColorTexture?.texCoord);
+            
+            this.shader.updateUniform("u_KHR_materials_specular_specularColorFactor", jsToGl(material.extensions?.KHR_materials_specular?.specularColorFactor));
+            this.shader.updateUniform("u_KHR_materials_specular_specularFactor", material.extensions?.KHR_materials_specular?.specularFactor);
+            this.shader.updateUniform("u_SpecularUVSet", material.extensions?.KHR_materials_specular?.specularTexture?.texCoord);
+            this.shader.updateUniform("u_SpecularColorUVSet", material.extensions?.KHR_materials_specular?.specularColorTexture?.texCoord);
+    
+            this.shader.updateUniform("u_TransmissionFactor", material.extensions?.KHR_materials_transmission?.transmissionFactor);
+            this.shader.updateUniform("u_TransmissionUVSet", material.extensions?.KHR_materials_transmission?.transmissionTexture?.texCoord);
+    
+            this.shader.updateUniform("u_AttenuationColor", jsToGl(material.extensions?.KHR_materials_volume?.attenuationColor));
+            this.shader.updateUniform("u_AttenuationDistance", material.extensions?.KHR_materials_volume?.attenuationDistance);
+            this.shader.updateUniform("u_ThicknessFactor", material.extensions?.KHR_materials_volume?.thicknessFactor);
+            this.shader.updateUniform("u_ThicknessUVSet", material.extensions?.KHR_materials_volume?.thicknessTexture?.texCoord);
+    
+            this.shader.updateUniform("u_DiffuseTransmissionFactor", material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionFactor);
+            this.shader.updateUniform("u_DiffuseTransmissionColorFactor", jsToGl(material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionColorFactor));
+            this.shader.updateUniform("u_DiffuseTransmissionUVSet", material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionTexture?.texCoord);
+            this.shader.updateUniform("u_DiffuseTransmissionColorUVSet", material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionColorTexture?.texCoord);
+    
+            this.shader.updateUniform("u_DiffuseFactor", jsToGl(material.extensions?.KHR_materials_pbrSpecularGlossiness?.diffuseFactor));
+            this.shader.updateUniform("u_SpecularFactor", jsToGl(material.extensions?.KHR_materials_pbrSpecularGlossiness?.specularFactor));
+            this.shader.updateUniform("u_GlossinessFactor", material.extensions?.KHR_materials_pbrSpecularGlossiness?.glossinessFactor);
+            this.shader.updateUniform("u_SpecularGlossinessUVSet", material.extensions?.KHR_materials_pbrSpecularGlossiness?.specularGlossinessTexture?.texCoord);
+            this.shader.updateUniform("u_DiffuseUVSet", material.extensions?.KHR_materials_pbrSpecularGlossiness?.diffuseTexture?.texCoord);
         
-        this.shader.updateUniform("u_MetallicRoughnessUVSet", material.pbrMetallicRoughness?.metallicRoughnessTexture?.texCoord);
-        this.shader.updateUniform("u_MetallicFactor", material.pbrMetallicRoughness?.metallicFactor);
-        this.shader.updateUniform("u_RoughnessFactor", material.pbrMetallicRoughness?.roughnessFactor);
-        this.shader.updateUniform("u_BaseColorFactor", jsToGl(material.pbrMetallicRoughness?.baseColorFactor));
-
-        this.shader.updateUniform("u_AnisotropyUVSet", material.extensions?.KHR_materials_anisotropy?.anisotropyTexture?.texCoord);
-
-        const factor = material.extensions?.KHR_materials_anisotropy?.anisotropyStrength;
-        const rotation = material.extensions?.KHR_materials_anisotropy?.anisotropyRotation;
-        const anisotropy =  vec3.fromValues(Math.cos(rotation ?? 0), Math.sin(rotation ?? 0), factor ?? 0.0);
-        this.shader.updateUniform("u_Anisotropy", anisotropy);
-
-        this.shader.updateUniform("u_ClearcoatFactor", material.extensions?.KHR_materials_clearcoat?.clearcoatFactor);
-        this.shader.updateUniform("u_ClearcoatRoughnessFactor", material.extensions?.KHR_materials_clearcoat?.clearcoatRoughnessFactor);
-        this.shader.updateUniform("u_ClearcoatUVSet", material.extensions?.KHR_materials_clearcoat?.clearcoatTexture?.texCoord);
-        this.shader.updateUniform("u_ClearcoatRoughnessUVSet", material.extensions?.KHR_materials_clearcoat?.clearcoatRoughnessTexture?.texCoord);
-        this.shader.updateUniform("u_ClearcoatNormalUVSet", material.extensions?.KHR_materials_clearcoat?.clearcoatNormalTexture?.texCoord);
-        this.shader.updateUniform("u_ClearcoatNormalScale", material.extensions?.KHR_materials_clearcoat?.clearcoatNormalTexture?.scale);
-
-        this.shader.updateUniform("u_Dispersion", material.extensions?.KHR_materials_dispersion?.dispersion);
-
-        this.shader.updateUniform("u_EmissiveStrength", material.extensions?.KHR_materials_emissive_strength?.emissiveStrength);
-
-        this.shader.updateUniform("u_Ior", material.extensions?.KHR_materials_ior?.ior);
-
-        this.shader.updateUniform("u_IridescenceFactor", material.extensions?.KHR_materials_iridescence?.iridescenceFactor);
-        this.shader.updateUniform("u_IridescenceIor", material.extensions?.KHR_materials_iridescence?.iridescenceIor);
-        this.shader.updateUniform("u_IridescenceThicknessMaximum", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessMaximum);
-        this.shader.updateUniform("u_IridescenceUVSet", material.extensions?.KHR_materials_iridescence?.iridescenceTexture?.texCoord);
-        this.shader.updateUniform("u_IridescenceThicknessUVSet", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessTexture?.texCoord);
-        this.shader.updateUniform("u_IridescenceThicknessMinimum", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessMinimum);
-
-        this.shader.updateUniform("u_SheenRoughnessFactor", material.extensions?.KHR_materials_sheen?.sheenRoughnessFactor);
-        this.shader.updateUniform("u_SheenColorFactor", jsToGl(material.extensions?.KHR_materials_sheen?.sheenColorFactor));
-        this.shader.updateUniform("u_SheenRoughnessUVSet", material.extensions?.KHR_materials_sheen?.sheenRoughnessTexture?.texCoord);
-        this.shader.updateUniform("u_SheenColorUVSet", material.extensions?.KHR_materials_sheen?.sheenColorTexture?.texCoord);
-        
-        this.shader.updateUniform("u_KHR_materials_specular_specularColorFactor", jsToGl(material.extensions?.KHR_materials_specular?.specularColorFactor));
-        this.shader.updateUniform("u_KHR_materials_specular_specularFactor", material.extensions?.KHR_materials_specular?.specularFactor);
-        this.shader.updateUniform("u_SpecularUVSet", material.extensions?.KHR_materials_specular?.specularTexture?.texCoord);
-        this.shader.updateUniform("u_SpecularColorUVSet", material.extensions?.KHR_materials_specular?.specularColorTexture?.texCoord);
-
-        this.shader.updateUniform("u_TransmissionFactor", material.extensions?.KHR_materials_transmission?.transmissionFactor);
-        this.shader.updateUniform("u_TransmissionUVSet", material.extensions?.KHR_materials_transmission?.transmissionTexture?.texCoord);
-
-        this.shader.updateUniform("u_AttenuationColor", jsToGl(material.extensions?.KHR_materials_volume?.attenuationColor));
-        this.shader.updateUniform("u_AttenuationDistance", material.extensions?.KHR_materials_volume?.attenuationDistance);
-        this.shader.updateUniform("u_ThicknessFactor", material.extensions?.KHR_materials_volume?.thicknessFactor);
-        this.shader.updateUniform("u_ThicknessUVSet", material.extensions?.KHR_materials_volume?.thicknessTexture?.texCoord);
-
-        this.shader.updateUniform("u_DiffuseTransmissionFactor", material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionFactor);
-        this.shader.updateUniform("u_DiffuseTransmissionColorFactor", jsToGl(material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionColorFactor));
-        this.shader.updateUniform("u_DiffuseTransmissionUVSet", material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionTexture?.texCoord);
-        this.shader.updateUniform("u_DiffuseTransmissionColorUVSet", material.extensions?.KHR_materials_diffuse_transmission?.diffuseTransmissionColorTexture?.texCoord);
-
-        this.shader.updateUniform("u_DiffuseFactor", jsToGl(material.extensions?.KHR_materials_pbrSpecularGlossiness?.diffuseFactor));
-        this.shader.updateUniform("u_SpecularFactor", jsToGl(material.extensions?.KHR_materials_pbrSpecularGlossiness?.specularFactor));
-        this.shader.updateUniform("u_GlossinessFactor", material.extensions?.KHR_materials_pbrSpecularGlossiness?.glossinessFactor);
-        this.shader.updateUniform("u_SpecularGlossinessUVSet", material.extensions?.KHR_materials_pbrSpecularGlossiness?.specularGlossinessTexture?.texCoord);
-        this.shader.updateUniform("u_DiffuseUVSet", material.extensions?.KHR_materials_pbrSpecularGlossiness?.diffuseTexture?.texCoord);
-
+        }
         let textureIndex = 0;
         for (; textureIndex < material.textures.length; ++textureIndex)
         {
@@ -588,6 +607,7 @@ class gltfRenderer
                 continue;
             }
         }
+
 
         // set the morph target texture
         if (primitive.morphTargetTextureInfo !== undefined) 
@@ -651,6 +671,7 @@ class gltfRenderer
             }
             this.webGl.context.disableVertexAttribArray(location);
         }
+        this.firstDraw = false;
     }
 
     /// Compute a list of lights instantiated by one or more nodes as a list of node-light tuples.

--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -442,6 +442,10 @@ class gltfRenderer
         }
 
         let fragDefines = material.getDefines(state.renderingParameters).concat(vertDefines);
+        if (renderpassConfiguration.linearOutput)
+        {
+            fragDefines.push("LINEAR_OUTPUT 1");
+        }
 
         // POINTS, LINES, LINE_LOOP, LINE_STRIP
         if (primitive.mode < 4) {

--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -84,7 +84,8 @@ class gltfRenderer
         this.lightFill.direction = vec3.create();
         vec3.transformQuat(this.lightKey.direction, [0, 0, -1], quatKey);
         vec3.transformQuat(this.lightFill.direction, [0, 0, -1], quatFill);
-
+        
+        this.maxVertAttributes = undefined;
         this.instanceBuffer = undefined;
     }
 
@@ -151,6 +152,8 @@ class gltfRenderer
             context.framebufferTexture2D(context.FRAMEBUFFER, context.DEPTH_ATTACHMENT, context.TEXTURE_2D, this.opaqueDepthTexture, 0);
             context.viewport(0, 0, this.opaqueFramebufferWidth, this.opaqueFramebufferHeight);
             context.bindFramebuffer(context.FRAMEBUFFER, null);
+
+            this.maxVertAttributes = context.getParameter(context.MAX_VERTEX_ATTRIBS);
 
             this.initialized = true;
 
@@ -225,7 +228,7 @@ class gltfRenderer
         this.opaqueDrawables = Object.groupBy(this.opaqueDrawables, (a) => {
             const winding = Math.sign(mat4.determinant(a.node.worldTransform));
             const id = `${a.node.mesh}_${winding}`;
-            if (a.node.skin || a.primitive.targets.length > 0) {
+            if (a.node.skin || a.primitive.targets.length > 0 || a.primitive.glAttributes.length + 4 > this.maxVertAttributes) {
                 counter++;
                 return id + "_" + counter;
             }

--- a/source/Renderer/shaders/pbr.frag
+++ b/source/Renderer/shaders/pbr.frag
@@ -367,7 +367,11 @@ void main()
     baseColor.a = 1.0;
 #endif
 
+#ifdef LINEAR_OUTPUT
+    g_finalColor = vec4(color.rgb, baseColor.a);
+#else
     g_finalColor = vec4(toneMap(color), baseColor.a);
+#endif
 
 #else
     // In case of missing data for a debug view, render a checkerboard.

--- a/source/Renderer/shaders/pbr.frag
+++ b/source/Renderer/shaders/pbr.frag
@@ -367,11 +367,7 @@ void main()
     baseColor.a = 1.0;
 #endif
 
-#ifdef LINEAR_OUTPUT
-    g_finalColor = vec4(color.rgb, baseColor.a);
-#else
     g_finalColor = vec4(toneMap(color), baseColor.a);
-#endif
 
 #else
     // In case of missing data for a debug view, render a checkerboard.

--- a/source/Renderer/shaders/primitive.vert
+++ b/source/Renderer/shaders/primitive.vert
@@ -43,6 +43,9 @@ in vec4 a_color_0;
 out vec4 v_Color;
 #endif
 
+#ifdef USE_INSTANCING
+in mat4 a_instance_model_matrix;
+#endif
 
 vec4 getPosition()
 {
@@ -100,18 +103,25 @@ vec3 getTangent()
 void main()
 {
     gl_PointSize = 1.0f;
-    vec4 pos = u_ModelMatrix * getPosition();
+#ifdef USE_INSTANCING
+    mat4 modelMatrix = a_instance_model_matrix;
+    mat4 normalMatrix = transpose(inverse(modelMatrix));
+#else
+    mat4 modelMatrix = u_ModelMatrix;
+    mat4 normalMatrix = u_NormalMatrix;
+#endif
+    vec4 pos = modelMatrix * getPosition();
     v_Position = vec3(pos.xyz) / pos.w;
 
 #ifdef HAS_NORMAL_VEC3
 #ifdef HAS_TANGENT_VEC4
     vec3 tangent = getTangent();
-    vec3 normalW = normalize(vec3(u_NormalMatrix * vec4(getNormal(), 0.0)));
-    vec3 tangentW = normalize(vec3(u_ModelMatrix * vec4(tangent, 0.0)));
+    vec3 normalW = normalize(vec3(normalMatrix * vec4(getNormal(), 0.0)));
+    vec3 tangentW = normalize(vec3(modelMatrix * vec4(tangent, 0.0)));
     vec3 bitangentW = cross(normalW, tangentW) * a_tangent.w;
     v_TBN = mat3(tangentW, bitangentW, normalW);
 #else
-    v_Normal = normalize(vec3(u_NormalMatrix * vec4(getNormal(), 0.0)));
+    v_Normal = normalize(vec3(normalMatrix * vec4(getNormal(), 0.0)));
 #endif
 #endif
 

--- a/source/gltf/primitive.js
+++ b/source/gltf/primitive.js
@@ -92,10 +92,7 @@ class gltfPrimitive extends GltfObject
                 console.error("To many vertex attributes for this primitive, skipping " + attribute);
                 break;
             }
-
-            const idx = this.attributes[attribute];
-            this.glAttributes.push({ attribute: attribute, name: "a_" + attribute.toLowerCase(), accessor: idx });
-            this.defines.push(`HAS_${attribute}_${gltf.accessors[idx].type} 1`);
+            let knownAttribute = true;
             switch (attribute)
             {
             case "POSITION":
@@ -129,7 +126,13 @@ class gltfPrimitive extends GltfObject
                 this.hasWeights = true;
                 break;
             default:
+                knownAttribute = false;
                 console.log("Unknown attribute: " + attribute);
+            }
+            if (knownAttribute) {
+                const idx = this.attributes[attribute];
+                this.glAttributes.push({ attribute: attribute, name: "a_" + attribute.toLowerCase(), accessor: idx });
+                this.defines.push(`HAS_${attribute}_${gltf.accessors[idx].type} 1`);
             }
         }
 


### PR DESCRIPTION
Use instancing in case meshes are reused.
Only used if GPU supports the additional vertex attributes.
Not used if mesh is used for morphing or skinning.

Can be optimized in the future to use one less vertex attribute (by omitting the last matrix row).
A fallback using UBO or data textures could be implemented if the vertex attribute limit is reached (but these have other limitations).
Vertex attributes are the fastest method and do not have a limit on the number of instances.
Currently the maximum amount of vertex attributes is 10 (position, normal, tangent, texcoord_0, texcoord_1, color_0 + 4 for instancing)