### PR TITLE
Remove unused u_inputTexture uniform in panorama_to_cubemap.frag

### DIFF
--- a/source/shaders/panorama_to_cubemap.frag
+++ b/source/shaders/panorama_to_cubemap.frag
@@ -10,7 +10,6 @@ out vec4 fragmentColor;
 
 uniform int u_currentFace;
 
-uniform sampler2D u_inputTexture;
 uniform sampler2D u_panorama;
 
 vec3 uvToXYZ(int face, vec2 uv)


### PR DESCRIPTION
This uniform is not used in the shader code.