### PR TITLE
Fix 1-element weight arrays being accidentally turned into scalars

### DIFF
--- a/source/gltf/animation.js
+++ b/source/gltf/animation.js
@@ -152,7 +152,7 @@ class gltfAnimation extends GltfObject
                     }
                     animatedProperty.animate(array);
                 } else {
-                    if (interpolant.length == 1 && back !== "weights") {
+                    if (interpolant.length == 1 && !Array.isArray(animatedProperty.restValue)) {
                         animatedProperty.animate(interpolant[0]);
                     }
                     else {

--- a/source/gltf/animation.js
+++ b/source/gltf/animation.js
@@ -140,8 +140,7 @@ class gltfAnimation extends GltfObject
                 // The interpolator will always return a `Float32Array`, even if the animated value is a scalar.
                 // For the renderer it's not a problem because uploading a single-element array is the same as uploading a scalar to a uniform.
                 // However, it becomes a problem if we use the animated value for further computation and assume is stays a scalar.
-                // Thus we explicitly convert the animated value back to a scalar if the interpolant is a single-element array.
-                // "weights" are a special case, because they can be arrays with a single element and should still stay arrays.
+                // Thus we explicitly convert the animated value back to a scalar if the interpolant is a single-element array and the rest value is not an array itself.
                 if (animatedArrayElement !== undefined) {
                     const array = animatedProperty.value();
                     if (interpolant.length == 1) {

--- a/source/gltf/animation.js
+++ b/source/gltf/animation.js
@@ -141,6 +141,7 @@ class gltfAnimation extends GltfObject
                 // For the renderer it's not a problem because uploading a single-element array is the same as uploading a scalar to a uniform.
                 // However, it becomes a problem if we use the animated value for further computation and assume is stays a scalar.
                 // Thus we explicitly convert the animated value back to a scalar if the interpolant is a single-element array.
+                // "weights" are a special case, because they can be arrays with a single element and should still stay arrays.
                 if (animatedArrayElement !== undefined) {
                     const array = animatedProperty.value();
                     if (interpolant.length == 1) {
@@ -151,7 +152,7 @@ class gltfAnimation extends GltfObject
                     }
                     animatedProperty.animate(array);
                 } else {
-                    if (interpolant.length == 1) {
+                    if (interpolant.length == 1 && back !== "weights") {
                         animatedProperty.animate(interpolant[0]);
                     }
                     else {


### PR DESCRIPTION
In the case that an animated weights array only had a single element, this array has been internally reduced to a scalar value. This broke the code for uploading the weights information as a uniform. 
This bug is fixed by adding an exception specifically for the case of weights, since they are the only property so far that can hold an array of length 1.

Fixes KhronosGroup/glTF-Sample-Viewer#590