### PR TITLE
read file type from file content instead of file extension

### DIFF
--- a/source/ResourceLoader/resource_loader.js
+++ b/source/ResourceLoader/resource_loader.js
@@ -52,9 +52,18 @@ class ResourceLoader
         let filename = "";
         if (typeof gltfFile === "string")
         {
-            isGlb = getIsGlb(gltfFile);
             const response = await fetch(gltfFile);
-            json = data = await (isGlb ? response.arrayBuffer() : response.json());
+            const responseData = await response.arrayBuffer();
+            const uintData = new Uint8Array(responseData);
+            const fileMagicNumbers = new TextDecoder().decode(uintData.subarray(0, 5));
+
+            isGlb = fileMagicNumbers.startsWith("glTF");
+            if(isGlb) {
+                json = data = responseData;
+            } else {
+                json = data = JSON.parse(new TextDecoder().decode(uintData));
+            }
+
             filename = gltfFile;
         }
         else if (gltfFile instanceof ArrayBuffer)


### PR DESCRIPTION
When loading a glb via the "model" URL parameter get the file type from the files content and not from the file extension.
(Fixes loading for valid urls where the file is a glb but the file extension is missing)

fixes KhronosGroup/glTF-Sample-Viewer#586