### PR TITLE
Check all textureInfos to determine internal format

### DIFF
--- a/source/Renderer/webgl.js
+++ b/source/Renderer/webgl.js
@@ -88,7 +88,7 @@ class gltfWebGl
                 image.mimeType === ImageMimeType.HDR)
             {
                 // the check `GL.SRGB8_ALPHA8 === undefined` is needed as at the moment node-gles does not define the full format enum
-                const internalformat = (textureInfo.linear || GL.SRGB8_ALPHA8 === undefined) ? GL.RGBA : GL.SRGB8_ALPHA8;
+                const internalformat = (gltfTex.linear || GL.SRGB8_ALPHA8 === undefined) ? GL.RGBA : GL.SRGB8_ALPHA8;
                 this.context.texImage2D(image.type, image.miplevel, internalformat, GL.RGBA, GL.UNSIGNED_BYTE, image.image);
             }
 

--- a/source/gltf/texture.js
+++ b/source/gltf/texture.js
@@ -18,6 +18,7 @@ class gltfTexture extends GltfObject
         this.type = type;
         this.initialized = false;
         this.mipLevelCount = 0;
+        this.linear = true;
     }
 
     initGl(gltf, webGlContext)
@@ -78,6 +79,9 @@ class gltfTextureInfo extends GltfObject
 
     initGl(gltf, webGlContext)
     {
+        if (!this.linear) {
+            gltf.textures[this.index].linear = false;
+        }
         initGlForMembers(this, gltf, webGlContext);
     }
 


### PR DESCRIPTION
Fixes KhronosGroup/glTF-Sample-Viewer#596
Packed textures of the format GL.RGBA and GL.SRGB8_ALPHA8 are supported.
Therefore, it is currently not possible to reuse a channel with a different color space.