### PR TITLE
Ignore modelMatrix for skins

### DIFF
--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -796,7 +796,7 @@ class gltfRenderer
         if (state.renderingParameters.skinning && state.gltf.skins !== undefined)
         {
             const skin = state.gltf.skins[node.skin];
-            skin.computeJoints(state.gltf, node, this.webGl.context);
+            skin.computeJoints(state.gltf, this.webGl.context);
         }
     }
 

--- a/source/Renderer/shaders/primitive.vert
+++ b/source/Renderer/shaders/primitive.vert
@@ -114,7 +114,12 @@ void main()
     mat4 modelMatrix = u_ModelMatrix;
     mat4 normalMatrix = u_NormalMatrix;
 #endif
+
+#ifdef USE_SKINNING
+    vec4 pos = getPosition();
+#else
     vec4 pos = modelMatrix * getPosition();
+#endif
     v_Position = vec3(pos.xyz) / pos.w;
 
 #ifdef HAS_NORMAL_VEC3

--- a/source/gltf/skin.js
+++ b/source/gltf/skin.js
@@ -67,7 +67,7 @@ class gltfSkin extends GltfObject
         this.jointTextureInfo.generateMips = false;
     }
 
-    computeJoints(gltf, parentNode, webGlContext)
+    computeJoints(gltf, webGlContext)
     {
         let ibmAccessor = null;
         if (this.inverseBindMatrices !== undefined) {
@@ -90,7 +90,6 @@ class gltfSkin extends GltfObject
             if (ibmAccessor !== null) {
                 let ibm = jsToGlSlice(ibmAccessor, i * 16, 16);
                 mat4.mul(jointMatrix, jointMatrix, ibm);
-                mat4.mul(jointMatrix, parentNode.inverseWorldTransform, jointMatrix);
             }
 
             let normalMatrix = mat4.create();


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/609

Previously, the skin's node transform was applied in the vertex shader and removed via the jointMatrix.
Therefore, this also fixes skinning for meshes with undefined inverseBindMatrix.