### PR TITLE
Fix/camera node selection

### DIFF
--- a/API.md
+++ b/API.md
@@ -108,7 +108,7 @@ GltfState containing a state for visualization in GltfView
         * [.environment](#GltfState+environment)
         * [.userCamera](#GltfState+userCamera)
         * [.sceneIndex](#GltfState+sceneIndex)
-        * [.cameraIndex](#GltfState+cameraIndex)
+        * [.cameraNodeIndex](#GltfState+cameraNodeIndex)
         * [.animationIndices](#GltfState+animationIndices)
         * [.animationTimer](#GltfState+animationTimer)
         * [.variant](#GltfState+variant)
@@ -209,10 +209,10 @@ user camera @see UserCamera, convenient camera controls
 gltf scene that is visible in the view
 
 **Kind**: instance property of [<code>GltfState</code>](#GltfState)  
-<a name="GltfState+cameraIndex"></a>
+<a name="GltfState+cameraNodeIndex"></a>
 
-### gltfState.cameraIndex
-index of the camera that is used to render the view. a
+### gltfState.cameraNodeIndex
+index of the camera node that is used to render the view. a
 value of 'undefined' enables the user camera
 
 **Kind**: instance property of [<code>GltfState</code>](#GltfState)  

--- a/source/GltfState/gltf_state.js
+++ b/source/GltfState/gltf_state.js
@@ -22,10 +22,10 @@ class GltfState
         /** gltf scene that is visible in the view */
         this.sceneIndex = 0;
         /**
-         * index of the camera that is used to render the view. a
+         * index of the camera node that is used to render the view. a
          * value of 'undefined' enables the user camera
          */
-        this.cameraIndex = undefined;
+        this.cameraNodeIndex = undefined;
         /** indices of active animations */
         this.animationIndices = [];
         /** animation timer allows to control the animation time */

--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -263,14 +263,18 @@ class gltfRenderer
 
         let currentCamera = undefined;
 
-        if (state.cameraIndex === undefined)
+        if (state.cameraNodeIndex === undefined)
         {
             currentCamera = state.userCamera;
             currentCamera.perspective.aspectRatio = this.currentWidth / this.currentHeight;
         }
         else
         {
-            currentCamera = state.gltf.cameras[state.cameraIndex];
+            currentCamera = state.gltf.cameras[state.gltf.nodes[state.cameraNodeIndex].camera];
+            if (currentCamera === undefined) {
+                throw new Error("Camera is misconfigured.");
+            }
+            currentCamera.setNode(state.gltf, state.cameraNodeIndex);
         }
 
         let aspectHeight = this.currentHeight;

--- a/source/gltf/camera.js
+++ b/source/gltf/camera.js
@@ -33,28 +33,6 @@ class gltfCamera extends GltfObject
     initGl(gltf, webGlContext)
     {
         super.initGl(gltf, webGlContext);
-
-        let cameraIndex = undefined;
-        for (let i = 0; i < gltf.nodes.length; i++)
-        {
-            cameraIndex = gltf.nodes[i].camera;
-            if (cameraIndex === undefined)
-            {
-                continue;
-            }
-
-            if (gltf.cameras[cameraIndex] === this)
-            {
-                this.node = i;
-                break;
-            }
-        }
-
-        // cameraIndex stays undefined if camera is not assigned to any node
-        if(this.node === undefined && cameraIndex !== undefined)
-        {
-            console.error("Invalid node for camera " + cameraIndex);
-        }
     }
 
     sortPrimitivesByDepth(gltf, drawables)
@@ -150,8 +128,19 @@ class gltfCamera extends GltfObject
         return node.worldQuaternion;
     }
 
+    setNode(gltf, nodeIndex)
+    {
+        if (nodeIndex === undefined || nodeIndex < 0 || nodeIndex >= gltf.nodes.length || gltf.nodes[nodeIndex].camera === undefined) {
+            throw new Error("Invalid camera node index");
+        }
+        this.node = nodeIndex;
+    }
+
     getNode(gltf)
     {
+        if (this.node === undefined || this.node < 0 || this.node >= gltf.nodes.length || gltf.nodes[this.node].camera === undefined) {
+            throw new Error("Camera node is not defined");
+        }
         return gltf.nodes[this.node];
     }
 


### PR DESCRIPTION
The camera should be defined via the node, not the camera index.
The same camera can be used in multiple nodes.