### PR TITLE
Fixes bug with matrix decomposition and animations

### DIFF
--- a/source/gltf/node.js
+++ b/source/gltf/node.js
@@ -104,6 +104,10 @@ class gltfNode extends GltfObject {
     }
 
     getLocalTransform() {
+        // Matrices are never animated, so if a matrix is present we can just use it directly
+        if (this.matrix !== undefined) {
+            return this.matrix;
+        }
         return mat4.fromRotationTranslationScale(
             mat4.create(),
             this.rotation,


### PR DESCRIPTION
If the parent of an animation has a matrix we need to use the matrix for the world transform calculation instead of the decomposed values