### PR TITLE
Fix/absolute URLs

### DIFF
--- a/API.md
+++ b/API.md
@@ -143,6 +143,7 @@ GltfState containing a state for visualization in GltfView
                 * [.GEOMETRYNORMAL](#GltfState.DebugOutput.generic.GEOMETRYNORMAL)
                 * [.TANGENT](#GltfState.DebugOutput.generic.TANGENT)
                 * [.BITANGENT](#GltfState.DebugOutput.generic.BITANGENT)
+                * [.TANGENTW](#GltfState.DebugOutput.generic.TANGENTW)
                 * [.WORLDSPACENORMAL](#GltfState.DebugOutput.generic.WORLDSPACENORMAL)
                 * [.ALPHA](#GltfState.DebugOutput.generic.ALPHA)
                 * [.OCCLUSION](#GltfState.DebugOutput.generic.OCCLUSION)
@@ -408,6 +409,7 @@ such as "NORMAL"
         * [.GEOMETRYNORMAL](#GltfState.DebugOutput.generic.GEOMETRYNORMAL)
         * [.TANGENT](#GltfState.DebugOutput.generic.TANGENT)
         * [.BITANGENT](#GltfState.DebugOutput.generic.BITANGENT)
+        * [.TANGENTW](#GltfState.DebugOutput.generic.TANGENTW)
         * [.WORLDSPACENORMAL](#GltfState.DebugOutput.generic.WORLDSPACENORMAL)
         * [.ALPHA](#GltfState.DebugOutput.generic.ALPHA)
         * [.OCCLUSION](#GltfState.DebugOutput.generic.OCCLUSION)
@@ -459,6 +461,7 @@ generic debug outputs
     * [.GEOMETRYNORMAL](#GltfState.DebugOutput.generic.GEOMETRYNORMAL)
     * [.TANGENT](#GltfState.DebugOutput.generic.TANGENT)
     * [.BITANGENT](#GltfState.DebugOutput.generic.BITANGENT)
+    * [.TANGENTW](#GltfState.DebugOutput.generic.TANGENTW)
     * [.WORLDSPACENORMAL](#GltfState.DebugOutput.generic.WORLDSPACENORMAL)
     * [.ALPHA](#GltfState.DebugOutput.generic.ALPHA)
     * [.OCCLUSION](#GltfState.DebugOutput.generic.OCCLUSION)
@@ -498,6 +501,12 @@ output the tangent from the TBN
 
 ##### generic.BITANGENT
 output the bitangent from the TBN
+
+**Kind**: static property of [<code>generic</code>](#GltfState.DebugOutput.generic)  
+<a name="GltfState.DebugOutput.generic.TANGENTW"></a>
+
+##### generic.TANGENTW
+output the tangent w from the TBN (black corresponds to -1; white to 1
 
 **Kind**: static property of [<code>generic</code>](#GltfState.DebugOutput.generic)  
 <a name="GltfState.DebugOutput.generic.WORLDSPACENORMAL"></a>
@@ -732,7 +741,7 @@ that are then used to display the loaded data with GltfView
 
 * [ResourceLoader](#ResourceLoader)
     * [new ResourceLoader(view, libPath)](#new_ResourceLoader_new)
-    * [.loadGltf(gltfFile, [externalFiles])](#ResourceLoader+loadGltf) ⇒ <code>Promise</code>
+    * [.loadGltf(gltfFile, [externalFiles], allowResourceAbsolutePath)](#ResourceLoader+loadGltf) ⇒ <code>Promise</code>
     * [.loadEnvironment(environmentFile, [lutFiles])](#ResourceLoader+loadEnvironment) ⇒ <code>Promise</code>
     * [.initKtxLib([externalKtxLib])](#ResourceLoader+initKtxLib)
     * [.initDracoLib([externalDracoLib])](#ResourceLoader+initDracoLib)
@@ -753,16 +762,17 @@ are allocated directly on the WebGl2 Context
 
 <a name="ResourceLoader+loadGltf"></a>
 
-### resourceLoader.loadGltf(gltfFile, [externalFiles]) ⇒ <code>Promise</code>
+### resourceLoader.loadGltf(gltfFile, [externalFiles], allowResourceAbsolutePath) ⇒ <code>Promise</code>
 loadGltf asynchroneously and create resources for rendering
 
 **Kind**: instance method of [<code>ResourceLoader</code>](#ResourceLoader)  
 **Returns**: <code>Promise</code> - a promise that fulfills when the gltf file was loaded  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| gltfFile | <code>String</code> \| <code>ArrayBuffer</code> \| <code>File</code> | the .gltf or .glb file either as path or as preloaded resource. In node.js environments, only ArrayBuffer types are accepted. |
-| [externalFiles] | <code>Array.&lt;File&gt;</code> | additional files containing resources that are referenced in the gltf |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| gltfFile | <code>String</code> \| <code>ArrayBuffer</code> \| <code>File</code> |  | the .gltf or .glb file either as path or as preloaded resource. In node.js environments, only ArrayBuffer types are accepted. |
+| [externalFiles] | <code>Array.&lt;File&gt;</code> |  | additional files containing resources that are referenced in the gltf |
+| allowResourceAbsolutePath | <code>Boolean</code> | <code>true</code> | whether to allow absolute paths for images/buffers. |
 
 <a name="ResourceLoader+loadEnvironment"></a>
 

--- a/API.md
+++ b/API.md
@@ -13,6 +13,11 @@ that are then used to display the loaded data with GltfView</p>
 </dd>
 <dt><a href="#UserCamera">UserCamera</a></dt>
 <dd></dd>
+<dt><a href="#ResourceLoaderUtils">ResourceLoaderUtils</a></dt>
+<dd><p>Utility class providing static helper methods for resource loading operations,
+such as extracting file extensions, resolving folder paths, normalizing relative
+paths, and detecting absolute URLs.</p>
+</dd>
 </dl>
 
 <a name="GltfView"></a>
@@ -1001,4 +1006,65 @@ Fit view to updated canvas size without changing rotation if distance is incorre
 | --- | --- |
 | gltf | <code>Gltf</code> | 
 | sceneIndex | <code>number</code> | 
+
+<a name="ResourceLoaderUtils"></a>
+
+## ResourceLoaderUtils
+Utility class providing static helper methods for resource loading operations,such as extracting file extensions, resolving folder paths, normalizing relativepaths, and detecting absolute URLs.
+
+**Kind**: global class  
+
+* [ResourceLoaderUtils](#ResourceLoaderUtils)
+    * [.getExtension(filename)](#ResourceLoaderUtils.getExtension) ⇒ <code>string</code> \| <code>undefined</code>
+    * [.getContainingFolder(filePath)](#ResourceLoaderUtils.getContainingFolder) ⇒ <code>string</code>
+    * [.cleanRelativePath(relativePath)](#ResourceLoaderUtils.cleanRelativePath) ⇒ <code>string</code>
+    * [.isAbsoluteUrl(url)](#ResourceLoaderUtils.isAbsoluteUrl) ⇒ <code>boolean</code>
+
+<a name="ResourceLoaderUtils.getExtension"></a>
+
+### ResourceLoaderUtils.getExtension(filename) ⇒ <code>string</code> \| <code>undefined</code>
+Extracts the file extension from a filename.
+
+**Kind**: static method of [<code>ResourceLoaderUtils</code>](#ResourceLoaderUtils)  
+**Returns**: <code>string</code> \| <code>undefined</code> - The lowercase file extension (without the leading dot),  or `undefined` if the filename has no extension.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| filename | <code>string</code> | The filename or path to extract the extension from. |
+
+<a name="ResourceLoaderUtils.getContainingFolder"></a>
+
+### ResourceLoaderUtils.getContainingFolder(filePath) ⇒ <code>string</code>
+Returns the directory portion of a file path, including the trailing slash.
+
+**Kind**: static method of [<code>ResourceLoaderUtils</code>](#ResourceLoaderUtils)  
+**Returns**: <code>string</code> - The path up to and including the last `/`, or an empty string  if no `/` is present.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| filePath | <code>string</code> | The full file path. |
+
+<a name="ResourceLoaderUtils.cleanRelativePath"></a>
+
+### ResourceLoaderUtils.cleanRelativePath(relativePath) ⇒ <code>string</code>
+Normalizes a relative URL path by resolving `.` and `..` segments.- Strips a leading `./` prefix.- Collapses `/./` sequences to `/`.- Resolves `/../` sequences by removing the preceding path segment.
+
+**Kind**: static method of [<code>ResourceLoaderUtils</code>](#ResourceLoaderUtils)  
+**Returns**: <code>string</code> - The normalized path with dot segments resolved.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| relativePath | <code>string</code> | The relative path to clean. |
+
+<a name="ResourceLoaderUtils.isAbsoluteUrl"></a>
+
+### ResourceLoaderUtils.isAbsoluteUrl(url) ⇒ <code>boolean</code>
+Determines whether a URL is absolute (i.e. contains a scheme such as `http:` or `data:`).A URL is considered absolute when it contains a `:` that appears before any `/`.
+
+**Kind**: static method of [<code>ResourceLoaderUtils</code>](#ResourceLoaderUtils)  
+**Returns**: <code>boolean</code> - `true` if the URL is absolute, `false` otherwise.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| url | <code>string</code> | The URL string to test. |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "concurrently": "^8.2.2",
                 "eslint": "^9.5.0",
                 "eslint-config-prettier": "^10.1.8",
-                "jsdoc-to-markdown": "^8.0.1",
+                "jsdoc-to-markdown": "^9.1.3",
                 "prettier": "3.6.2",
                 "rollup": "^4.23.0",
                 "rollup-plugin-copy": "^3.5.0",
@@ -33,30 +33,30 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-            "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.25.6"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -75,14 +75,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-            "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.24.8",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -301,12 +300,12 @@
             "dev": true
         },
         "node_modules/@jsdoc/salty": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
-            "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.11.tgz",
+            "integrity": "sha512-luR/TZqgru6gNjBQnRIbzNPOmDG62VIFQO7QyEjc1/zk3VP3yoGfuecwP2uOlAmKz+t6aq9bwsBV3FgiyHTT7Q==",
             "dev": true,
             "dependencies": {
-                "lodash": "^4.17.21"
+                "lodash": "^4.17.23"
             },
             "engines": {
                 "node": ">=v12.0.0"
@@ -944,27 +943,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/ansi-escape-sequences": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-            "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
-            "dev": true,
-            "dependencies": {
-                "array-back": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
-        "node_modules/ansi-escape-sequences/node_modules/array-back": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-            "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1022,9 +1000,9 @@
             "dev": true
         },
         "node_modules/array-back": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-            "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+            "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
             "dev": true,
             "engines": {
                 "node": ">=12.17"
@@ -1142,26 +1120,23 @@
             }
         },
         "node_modules/cache-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-2.0.0.tgz",
-            "integrity": "sha512-4gkeHlFpSKgm3vm2gJN5sPqfmijYRFYCQ6tv5cLw0xVmT6r1z1vd4FNnpuOREco3cBs1G709sZ72LdgddKvL5w==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-3.0.1.tgz",
+            "integrity": "sha512-itTIMLEKbh6Dw5DruXbxAgcyLnh/oPGVLBfTPqBOftASxHe8bAeXy7JkO4F0LvHqht7XqP5O/09h5UcHS2w0FA==",
             "dev": true,
             "dependencies": {
-                "array-back": "^4.0.1",
-                "fs-then-native": "^2.0.0",
-                "mkdirp2": "^1.0.4"
+                "array-back": "^6.2.2"
             },
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cache-point/node_modules/array-back": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-            "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
+                "node": ">=12.17"
+            },
+            "peerDependencies": {
+                "@75lb/nature": "latest"
+            },
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
             }
         },
         "node_modules/callsites": {
@@ -1320,19 +1295,6 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
-        "node_modules/collect-all": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
-            "integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
-            "dev": true,
-            "dependencies": {
-                "stream-connect": "^1.0.2",
-                "stream-via": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1358,91 +1320,41 @@
             "dev": true
         },
         "node_modules/command-line-args": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-            "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+            "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
             "dev": true,
             "dependencies": {
-                "array-back": "^3.1.0",
-                "find-replace": "^3.0.0",
+                "array-back": "^6.2.3",
+                "find-replace": "^5.0.2",
                 "lodash.camelcase": "^4.3.0",
-                "typical": "^4.0.0"
+                "typical": "^7.3.0"
             },
             "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/command-line-args/node_modules/array-back": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-            "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/command-line-args/node_modules/typical": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-            "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/command-line-tool": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
-            "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
-            "dev": true,
-            "dependencies": {
-                "ansi-escape-sequences": "^4.0.0",
-                "array-back": "^2.0.0",
-                "command-line-args": "^5.0.0",
-                "command-line-usage": "^4.1.0",
-                "typical": "^2.6.1"
+                "node": ">=12.20"
             },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/command-line-tool/node_modules/array-back": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-            "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-            "dev": true,
-            "dependencies": {
-                "typical": "^2.6.1"
+            "peerDependencies": {
+                "@75lb/nature": "latest"
             },
-            "engines": {
-                "node": ">=4"
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
             }
         },
         "node_modules/command-line-usage": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-            "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+            "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
             "dev": true,
             "dependencies": {
-                "ansi-escape-sequences": "^4.0.0",
-                "array-back": "^2.0.0",
-                "table-layout": "^0.4.2",
-                "typical": "^2.6.1"
+                "array-back": "^6.2.2",
+                "chalk-template": "^0.4.0",
+                "table-layout": "^4.1.1",
+                "typical": "^7.3.0"
             },
             "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/command-line-usage/node_modules/array-back": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-            "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-            "dev": true,
-            "dependencies": {
-                "typical": "^2.6.1"
-            },
-            "engines": {
-                "node": ">=4"
+                "node": ">=12.20.0"
             }
         },
         "node_modules/commander": {
@@ -1458,12 +1370,12 @@
             "dev": true
         },
         "node_modules/common-sequence": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.2.tgz",
-            "integrity": "sha512-jAg09gkdkrDO9EWTdXfv80WWH3yeZl5oT69fGfedBNS9pXUKYInVJ1bJ+/ht2+Moeei48TmSbQDYMc8EOx9G0g==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-3.0.0.tgz",
+            "integrity": "sha512-g/CgSYk93y+a1IKm50tKl7kaT/OjjTYVQlEbUlt/49ZLV1mcKpUU7iyDiqTAeLdb4QDtQfq3ako8y8v//fzrWQ==",
             "dev": true,
             "engines": {
-                "node": ">=8"
+                "node": ">=12.17"
             }
         },
         "node_modules/commondir": {
@@ -1612,6 +1524,15 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/current-module-paths": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.3.tgz",
+            "integrity": "sha512-7AH+ZTRKikdK4s1RmY0l6067UD/NZc7p3zZVZxvmnH80G31kr0y0W0E6ibYM4IS01MEm8DiC5FnTcgcgkbFHoA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.17"
+            }
+        },
         "node_modules/date-fns": {
             "version": "2.30.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -1682,26 +1603,29 @@
             }
         },
         "node_modules/dmd": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.2.3.tgz",
-            "integrity": "sha512-SIEkjrG7cZ9GWZQYk/mH+mWtcRPly/3ibVuXO/tP/MFoWz6KiRK77tSMq6YQBPl7RljPtXPQ/JhxbNuCdi1bNw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/dmd/-/dmd-7.1.1.tgz",
+            "integrity": "sha512-Ap2HP6iuOek7eShReDLr9jluNJm9RMZESlt29H/Xs1qrVMkcS9X6m5h1mBC56WMxNiSo0wvjGICmZlYUSFjwZQ==",
             "dev": true,
             "dependencies": {
                 "array-back": "^6.2.2",
-                "cache-point": "^2.0.0",
-                "common-sequence": "^2.0.2",
-                "file-set": "^4.0.2",
+                "cache-point": "^3.0.0",
+                "common-sequence": "^3.0.0",
+                "file-set": "^5.2.2",
                 "handlebars": "^4.7.8",
                 "marked": "^4.3.0",
-                "object-get": "^2.1.1",
-                "reduce-flatten": "^3.0.1",
-                "reduce-unique": "^2.0.1",
-                "reduce-without": "^1.0.1",
-                "test-value": "^3.0.0",
-                "walk-back": "^5.1.0"
+                "walk-back": "^5.1.1"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=12.17"
+            },
+            "peerDependencies": {
+                "@75lb/nature": "latest"
+            },
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
             }
         },
         "node_modules/duplexify": {
@@ -2129,46 +2053,24 @@
             }
         },
         "node_modules/file-set": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/file-set/-/file-set-4.0.2.tgz",
-            "integrity": "sha512-fuxEgzk4L8waGXaAkd8cMr73Pm0FxOVkn8hztzUW7BAHhOGH90viQNXbiOsnecCWmfInqU6YmAMwxRMdKETceQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/file-set/-/file-set-5.3.0.tgz",
+            "integrity": "sha512-FKCxdjLX0J6zqTWdT0RXIxNF/n7MyXXnsSUp0syLEOCKdexvPZ02lNNv2a+gpK9E3hzUYF3+eFZe32ci7goNUg==",
             "dev": true,
             "dependencies": {
-                "array-back": "^5.0.0",
-                "glob": "^7.1.6"
+                "array-back": "^6.2.2",
+                "fast-glob": "^3.3.2"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/file-set/node_modules/array-back": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
-            "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/file-set/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "node": ">=12.17"
             },
-            "engines": {
-                "node": "*"
+            "peerDependencies": {
+                "@75lb/nature": "latest"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
             }
         },
         "node_modules/fill-range": {
@@ -2184,24 +2086,20 @@
             }
         },
         "node_modules/find-replace": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-            "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+            "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
             "dev": true,
-            "dependencies": {
-                "array-back": "^3.0.1"
+            "engines": {
+                "node": ">=14"
             },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/find-replace/node_modules/array-back": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-            "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
+            "peerDependencies": {
+                "@75lb/nature": "latest"
+            },
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
             }
         },
         "node_modules/find-up": {
@@ -2261,15 +2159,6 @@
             },
             "engines": {
                 "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/fs-then-native": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-            "integrity": "sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==",
-            "dev": true,
-            "engines": {
-                "node": ">=4.0.0"
             }
         },
         "node_modules/fs.realpath": {
@@ -2879,9 +2768,9 @@
             }
         },
         "node_modules/jsdoc": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
-            "integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+            "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
             "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.20.15",
@@ -2908,47 +2797,21 @@
             }
         },
         "node_modules/jsdoc-api": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-8.1.1.tgz",
-            "integrity": "sha512-yas9E4h8NHp1CTEZiU/DPNAvLoUcip+Hl8Xi1RBYzHqSrgsF+mImAZNtwymrXvgbrgl4bNGBU9syulM0JzFeHQ==",
+            "version": "9.3.5",
+            "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-9.3.5.tgz",
+            "integrity": "sha512-TQwh1jA8xtCkIbVwm/XA3vDRAa5JjydyKx1cC413Sh3WohDFxcMdwKSvn4LOsq2xWyAmOU/VnSChTQf6EF0R8g==",
             "dev": true,
             "dependencies": {
                 "array-back": "^6.2.2",
-                "cache-point": "^2.0.0",
-                "collect-all": "^1.0.4",
-                "file-set": "^4.0.2",
-                "fs-then-native": "^2.0.0",
-                "jsdoc": "^4.0.3",
+                "cache-point": "^3.0.1",
+                "current-module-paths": "^1.1.2",
+                "file-set": "^5.3.0",
+                "jsdoc": "^4.0.4",
                 "object-to-spawn-args": "^2.0.1",
-                "temp-path": "^1.0.0",
-                "walk-back": "^5.1.0"
+                "walk-back": "^5.1.1"
             },
             "engines": {
                 "node": ">=12.17"
-            }
-        },
-        "node_modules/jsdoc-parse": {
-            "version": "6.2.4",
-            "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.4.tgz",
-            "integrity": "sha512-MQA+lCe3ioZd0uGbyB3nDCDZcKgKC7m/Ivt0LgKZdUoOlMJxUWJQ3WI6GeyHp9ouznKaCjlp7CU9sw5k46yZTw==",
-            "dev": true,
-            "dependencies": {
-                "array-back": "^6.2.2",
-                "find-replace": "^5.0.1",
-                "lodash.omit": "^4.5.0",
-                "sort-array": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/jsdoc-parse/node_modules/find-replace": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
-            "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=14"
             },
             "peerDependencies": {
                 "@75lb/nature": "latest"
@@ -2959,25 +2822,48 @@
                 }
             }
         },
-        "node_modules/jsdoc-to-markdown": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-8.0.3.tgz",
-            "integrity": "sha512-JGYYd5xygnQt1DIxH+HUI+X/ynL8qWihzIF0n15NSCNtM6MplzawURRcaLI2WkiS2hIjRIgsphCOfM7FkaWiNg==",
+        "node_modules/jsdoc-parse": {
+            "version": "6.2.5",
+            "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.5.tgz",
+            "integrity": "sha512-8JaSNjPLr2IuEY4Das1KM6Z4oLHZYUnjRrr27hKSa78Cj0i5Lur3DzNnCkz+DfrKBDoljGMoWOiBVQbtUZJBPw==",
             "dev": true,
             "dependencies": {
                 "array-back": "^6.2.2",
-                "command-line-tool": "^0.8.0",
+                "find-replace": "^5.0.1",
+                "sort-array": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jsdoc-to-markdown": {
+            "version": "9.1.3",
+            "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.1.3.tgz",
+            "integrity": "sha512-i9wi+6WHX0WKziv0ar88T8h7OmxA0LWdQaV23nY6uQyKvdUPzVt0o6YAaOceFuKRF5Rvlju5w/KnZBfdpDAlnw==",
+            "dev": true,
+            "dependencies": {
+                "array-back": "^6.2.2",
+                "command-line-args": "^6.0.1",
+                "command-line-usage": "^7.0.3",
                 "config-master": "^3.1.0",
-                "dmd": "^6.2.3",
-                "jsdoc-api": "^8.1.1",
-                "jsdoc-parse": "^6.2.1",
-                "walk-back": "^5.1.0"
+                "dmd": "^7.1.1",
+                "jsdoc-api": "^9.3.5",
+                "jsdoc-parse": "^6.2.5",
+                "walk-back": "^5.1.1"
             },
             "bin": {
                 "jsdoc2md": "bin/cli.js"
             },
             "engines": {
                 "node": ">=12.17"
+            },
+            "peerDependencies": {
+                "@75lb/nature": "latest"
+            },
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
             }
         },
         "node_modules/jsdoc/node_modules/escape-string-regexp": {
@@ -3092,18 +2978,6 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "node_modules/lodash.omit": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-            "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-            "dev": true
-        },
-        "node_modules/lodash.padend": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-            "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
             "dev": true
         },
         "node_modules/magic-string": {
@@ -3284,12 +3158,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/mkdirp2": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.5.tgz",
-            "integrity": "sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==",
-            "dev": true
-        },
         "node_modules/moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -3343,12 +3211,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/object-get": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.1.tgz",
-            "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==",
-            "dev": true
         },
         "node_modules/object-to-spawn-args": {
             "version": "2.0.1",
@@ -3662,61 +3524,6 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
-        },
-        "node_modules/reduce-flatten": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.1.tgz",
-            "integrity": "sha512-bYo+97BmUUOzg09XwfkwALt4PQH1M5L0wzKerBt6WLm3Fhdd43mMS89HiT1B9pJIqko/6lWx3OnV4J9f2Kqp5Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/reduce-unique": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz",
-            "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/reduce-without": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-            "integrity": "sha512-zQv5y/cf85sxvdrKPlfcRzlDn/OqKFThNimYmsS3flmkioKvkUGn2Qg9cJVoQiEvdxFGLE0MQER/9fZ9sUqdxg==",
-            "dev": true,
-            "dependencies": {
-                "test-value": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/reduce-without/node_modules/array-back": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-            "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-            "dev": true,
-            "dependencies": {
-                "typical": "^2.6.0"
-            },
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
-        "node_modules/reduce-without/node_modules/test-value": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-            "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
-            "dev": true,
-            "dependencies": {
-                "array-back": "^1.0.3",
-                "typical": "^2.6.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/registry-auth-token": {
             "version": "3.3.2",
@@ -4119,9 +3926,9 @@
             }
         },
         "node_modules/sort-array": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.0.0.tgz",
-            "integrity": "sha512-Sg9MzajSGprcSrMIxsXyNT0e0JB47RJRfJspC+7co4Z5BdNsNl8FmWI+lXEpyKq+vkMG6pHgAhqyCO+bkDTfFQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.1.1.tgz",
+            "integrity": "sha512-EltS7AIsNlAFIM9cayrgKrM6XP94ATWwXP4LCL4IQbvbYhELSt2hZTrixg+AaQwnWFs/JGJgqU3rxMcNNWxGAA==",
             "dev": true,
             "dependencies": {
                 "array-back": "^6.2.2",
@@ -4137,15 +3944,6 @@
                 "@75lb/nature": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/sort-array/node_modules/typical": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/typical/-/typical-7.2.0.tgz",
-            "integrity": "sha512-W1+HdVRUl8fS3MZ9ogD51GOb46xMmhAZzR0WPw5jcgIZQJVvkddYzAl4YTU6g5w33Y1iRQLdIi2/1jhi2RNL0g==",
-            "dev": true,
-            "engines": {
-                "node": ">=12.17"
             }
         },
         "node_modules/source-map": {
@@ -4240,45 +4038,11 @@
                 "escodegen": "^2.1.0"
             }
         },
-        "node_modules/stream-connect": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-            "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "dependencies": {
-                "array-back": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/stream-connect/node_modules/array-back": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-            "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-            "dev": true,
-            "dependencies": {
-                "typical": "^2.6.0"
-            },
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
         "node_modules/stream-shift": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
             "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
             "dev": true
-        },
-        "node_modules/stream-via": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-            "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
@@ -4400,62 +4164,16 @@
             }
         },
         "node_modules/table-layout": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-            "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+            "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
             "dev": true,
             "dependencies": {
-                "array-back": "^2.0.0",
-                "deep-extend": "~0.6.0",
-                "lodash.padend": "^4.6.1",
-                "typical": "^2.6.1",
-                "wordwrapjs": "^3.0.0"
+                "array-back": "^6.2.2",
+                "wordwrapjs": "^5.1.0"
             },
             "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/table-layout/node_modules/array-back": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-            "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-            "dev": true,
-            "dependencies": {
-                "typical": "^2.6.1"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/temp-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-            "integrity": "sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==",
-            "dev": true
-        },
-        "node_modules/test-value": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-            "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-            "dev": true,
-            "dependencies": {
-                "array-back": "^2.0.0",
-                "typical": "^2.6.1"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/test-value/node_modules/array-back": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-            "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-            "dev": true,
-            "dependencies": {
-                "typical": "^2.6.1"
-            },
-            "engines": {
-                "node": ">=4"
+                "node": ">=12.17"
             }
         },
         "node_modules/through2": {
@@ -4466,15 +4184,6 @@
             "dependencies": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
-            }
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/to-regex-range": {
@@ -4535,10 +4244,13 @@
             "dev": true
         },
         "node_modules/typical": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-            "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-            "dev": true
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+            "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.17"
+            }
         },
         "node_modules/uc.micro": {
             "version": "2.1.0",
@@ -4615,12 +4327,20 @@
             }
         },
         "node_modules/walk-back": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.1.tgz",
-            "integrity": "sha512-e/FRLDVdZQWFrAzU6Hdvpm7D7m2ina833gIKLptQykRK49mmCYHLHq7UqjPDbxbKLZkTkW1rFqbengdE3sLfdw==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.2.tgz",
+            "integrity": "sha512-uCgzIY1U7fyXvJm+mesY0xjf2HXu7mtTnptONwVQ11ur1JhMrUyQJn2fDje1CGFQDnTFTo1Slr1vRuvUS9PYoQ==",
             "dev": true,
             "engines": {
                 "node": ">=12.17"
+            },
+            "peerDependencies": {
+                "@75lb/nature": "latest"
+            },
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
             }
         },
         "node_modules/which": {
@@ -4669,25 +4389,12 @@
             "dev": true
         },
         "node_modules/wordwrapjs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-            "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-            "dev": true,
-            "dependencies": {
-                "reduce-flatten": "^1.0.1",
-                "typical": "^2.6.1"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/wordwrapjs/node_modules/reduce-flatten": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-            "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+            "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
             "dev": true,
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=12.17"
             }
         },
         "node_modules/wrap-ansi": {
@@ -4838,24 +4545,24 @@
     },
     "dependencies": {
         "@babel/helper-string-parser": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.24.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true
         },
         "@babel/parser": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-            "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.25.6"
+                "@babel/types": "^7.29.0"
             }
         },
         "@babel/runtime": {
@@ -4865,14 +4572,13 @@
             "dev": true
         },
         "@babel/types": {
-            "version": "7.25.6",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-            "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.24.8",
-                "@babel/helper-validator-identifier": "^7.24.7",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
             }
         },
         "@choojs/findup": {
@@ -5018,12 +4724,12 @@
             "dev": true
         },
         "@jsdoc/salty": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
-            "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.11.tgz",
+            "integrity": "sha512-luR/TZqgru6gNjBQnRIbzNPOmDG62VIFQO7QyEjc1/zk3VP3yoGfuecwP2uOlAmKz+t6aq9bwsBV3FgiyHTT7Q==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.21"
+                "lodash": "^4.17.23"
             }
         },
         "@nodelib/fs.scandir": {
@@ -5428,23 +5134,6 @@
                 }
             }
         },
-        "ansi-escape-sequences": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-            "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
-            "dev": true,
-            "requires": {
-                "array-back": "^3.0.1"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-                    "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-                    "dev": true
-                }
-            }
-        },
         "ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -5479,9 +5168,9 @@
             "dev": true
         },
         "array-back": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-            "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+            "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
             "dev": true
         },
         "array-find-index": {
@@ -5574,22 +5263,12 @@
             "dev": true
         },
         "cache-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-2.0.0.tgz",
-            "integrity": "sha512-4gkeHlFpSKgm3vm2gJN5sPqfmijYRFYCQ6tv5cLw0xVmT6r1z1vd4FNnpuOREco3cBs1G709sZ72LdgddKvL5w==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-3.0.1.tgz",
+            "integrity": "sha512-itTIMLEKbh6Dw5DruXbxAgcyLnh/oPGVLBfTPqBOftASxHe8bAeXy7JkO4F0LvHqht7XqP5O/09h5UcHS2w0FA==",
             "dev": true,
             "requires": {
-                "array-back": "^4.0.1",
-                "fs-then-native": "^2.0.0",
-                "mkdirp2": "^1.0.4"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-                    "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-                    "dev": true
-                }
+                "array-back": "^6.2.2"
             }
         },
         "callsites": {
@@ -5701,16 +5380,6 @@
                 }
             }
         },
-        "collect-all": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
-            "integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
-            "dev": true,
-            "requires": {
-                "stream-connect": "^1.0.2",
-                "stream-via": "^1.0.4"
-            }
-        },
         "color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5733,76 +5402,27 @@
             "dev": true
         },
         "command-line-args": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-            "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+            "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
             "dev": true,
             "requires": {
-                "array-back": "^3.1.0",
-                "find-replace": "^3.0.0",
+                "array-back": "^6.2.3",
+                "find-replace": "^5.0.2",
                 "lodash.camelcase": "^4.3.0",
-                "typical": "^4.0.0"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-                    "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-                    "dev": true
-                },
-                "typical": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-                    "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-                    "dev": true
-                }
-            }
-        },
-        "command-line-tool": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
-            "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
-            "dev": true,
-            "requires": {
-                "ansi-escape-sequences": "^4.0.0",
-                "array-back": "^2.0.0",
-                "command-line-args": "^5.0.0",
-                "command-line-usage": "^4.1.0",
-                "typical": "^2.6.1"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-                    "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-                    "dev": true,
-                    "requires": {
-                        "typical": "^2.6.1"
-                    }
-                }
+                "typical": "^7.3.0"
             }
         },
         "command-line-usage": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-            "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+            "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
             "dev": true,
             "requires": {
-                "ansi-escape-sequences": "^4.0.0",
-                "array-back": "^2.0.0",
-                "table-layout": "^0.4.2",
-                "typical": "^2.6.1"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-                    "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-                    "dev": true,
-                    "requires": {
-                        "typical": "^2.6.1"
-                    }
-                }
+                "array-back": "^6.2.2",
+                "chalk-template": "^0.4.0",
+                "table-layout": "^4.1.1",
+                "typical": "^7.3.0"
             }
         },
         "commander": {
@@ -5818,9 +5438,9 @@
             "dev": true
         },
         "common-sequence": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.2.tgz",
-            "integrity": "sha512-jAg09gkdkrDO9EWTdXfv80WWH3yeZl5oT69fGfedBNS9pXUKYInVJ1bJ+/ht2+Moeei48TmSbQDYMc8EOx9G0g==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-3.0.0.tgz",
+            "integrity": "sha512-g/CgSYk93y+a1IKm50tKl7kaT/OjjTYVQlEbUlt/49ZLV1mcKpUU7iyDiqTAeLdb4QDtQfq3ako8y8v//fzrWQ==",
             "dev": true
         },
         "commondir": {
@@ -5945,6 +5565,12 @@
                 "which": "^2.0.1"
             }
         },
+        "current-module-paths": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.3.tgz",
+            "integrity": "sha512-7AH+ZTRKikdK4s1RmY0l6067UD/NZc7p3zZVZxvmnH80G31kr0y0W0E6ibYM4IS01MEm8DiC5FnTcgcgkbFHoA==",
+            "dev": true
+        },
         "date-fns": {
             "version": "2.30.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
@@ -5991,23 +5617,18 @@
             }
         },
         "dmd": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.2.3.tgz",
-            "integrity": "sha512-SIEkjrG7cZ9GWZQYk/mH+mWtcRPly/3ibVuXO/tP/MFoWz6KiRK77tSMq6YQBPl7RljPtXPQ/JhxbNuCdi1bNw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/dmd/-/dmd-7.1.1.tgz",
+            "integrity": "sha512-Ap2HP6iuOek7eShReDLr9jluNJm9RMZESlt29H/Xs1qrVMkcS9X6m5h1mBC56WMxNiSo0wvjGICmZlYUSFjwZQ==",
             "dev": true,
             "requires": {
                 "array-back": "^6.2.2",
-                "cache-point": "^2.0.0",
-                "common-sequence": "^2.0.2",
-                "file-set": "^4.0.2",
+                "cache-point": "^3.0.0",
+                "common-sequence": "^3.0.0",
+                "file-set": "^5.2.2",
                 "handlebars": "^4.7.8",
                 "marked": "^4.3.0",
-                "object-get": "^2.1.1",
-                "reduce-flatten": "^3.0.1",
-                "reduce-unique": "^2.0.1",
-                "reduce-without": "^1.0.1",
-                "test-value": "^3.0.0",
-                "walk-back": "^5.1.0"
+                "walk-back": "^5.1.1"
             }
         },
         "duplexify": {
@@ -6317,35 +5938,13 @@
             }
         },
         "file-set": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/file-set/-/file-set-4.0.2.tgz",
-            "integrity": "sha512-fuxEgzk4L8waGXaAkd8cMr73Pm0FxOVkn8hztzUW7BAHhOGH90viQNXbiOsnecCWmfInqU6YmAMwxRMdKETceQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/file-set/-/file-set-5.3.0.tgz",
+            "integrity": "sha512-FKCxdjLX0J6zqTWdT0RXIxNF/n7MyXXnsSUp0syLEOCKdexvPZ02lNNv2a+gpK9E3hzUYF3+eFZe32ci7goNUg==",
             "dev": true,
             "requires": {
-                "array-back": "^5.0.0",
-                "glob": "^7.1.6"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
-                    "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
-                    "dev": true
-                },
-                "glob": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-                    "dev": true,
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.1.1",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                }
+                "array-back": "^6.2.2",
+                "fast-glob": "^3.3.2"
             }
         },
         "fill-range": {
@@ -6358,21 +5957,11 @@
             }
         },
         "find-replace": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-            "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+            "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
             "dev": true,
-            "requires": {
-                "array-back": "^3.0.1"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-                    "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-                    "dev": true
-                }
-            }
+            "requires": {}
         },
         "find-up": {
             "version": "5.0.0",
@@ -6420,12 +6009,6 @@
                 "jsonfile": "^4.0.0",
                 "universalify": "^0.1.0"
             }
-        },
-        "fs-then-native": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-            "integrity": "sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==",
-            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -6918,9 +6501,9 @@
             }
         },
         "jsdoc": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
-            "integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+            "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.20.15",
@@ -6949,56 +6532,45 @@
             }
         },
         "jsdoc-api": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-8.1.1.tgz",
-            "integrity": "sha512-yas9E4h8NHp1CTEZiU/DPNAvLoUcip+Hl8Xi1RBYzHqSrgsF+mImAZNtwymrXvgbrgl4bNGBU9syulM0JzFeHQ==",
+            "version": "9.3.5",
+            "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-9.3.5.tgz",
+            "integrity": "sha512-TQwh1jA8xtCkIbVwm/XA3vDRAa5JjydyKx1cC413Sh3WohDFxcMdwKSvn4LOsq2xWyAmOU/VnSChTQf6EF0R8g==",
             "dev": true,
             "requires": {
                 "array-back": "^6.2.2",
-                "cache-point": "^2.0.0",
-                "collect-all": "^1.0.4",
-                "file-set": "^4.0.2",
-                "fs-then-native": "^2.0.0",
-                "jsdoc": "^4.0.3",
+                "cache-point": "^3.0.1",
+                "current-module-paths": "^1.1.2",
+                "file-set": "^5.3.0",
+                "jsdoc": "^4.0.4",
                 "object-to-spawn-args": "^2.0.1",
-                "temp-path": "^1.0.0",
-                "walk-back": "^5.1.0"
+                "walk-back": "^5.1.1"
             }
         },
         "jsdoc-parse": {
-            "version": "6.2.4",
-            "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.4.tgz",
-            "integrity": "sha512-MQA+lCe3ioZd0uGbyB3nDCDZcKgKC7m/Ivt0LgKZdUoOlMJxUWJQ3WI6GeyHp9ouznKaCjlp7CU9sw5k46yZTw==",
+            "version": "6.2.5",
+            "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.5.tgz",
+            "integrity": "sha512-8JaSNjPLr2IuEY4Das1KM6Z4oLHZYUnjRrr27hKSa78Cj0i5Lur3DzNnCkz+DfrKBDoljGMoWOiBVQbtUZJBPw==",
             "dev": true,
             "requires": {
                 "array-back": "^6.2.2",
                 "find-replace": "^5.0.1",
-                "lodash.omit": "^4.5.0",
                 "sort-array": "^5.0.0"
-            },
-            "dependencies": {
-                "find-replace": {
-                    "version": "5.0.2",
-                    "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
-                    "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
-                    "dev": true,
-                    "requires": {}
-                }
             }
         },
         "jsdoc-to-markdown": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-8.0.3.tgz",
-            "integrity": "sha512-JGYYd5xygnQt1DIxH+HUI+X/ynL8qWihzIF0n15NSCNtM6MplzawURRcaLI2WkiS2hIjRIgsphCOfM7FkaWiNg==",
+            "version": "9.1.3",
+            "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.1.3.tgz",
+            "integrity": "sha512-i9wi+6WHX0WKziv0ar88T8h7OmxA0LWdQaV23nY6uQyKvdUPzVt0o6YAaOceFuKRF5Rvlju5w/KnZBfdpDAlnw==",
             "dev": true,
             "requires": {
                 "array-back": "^6.2.2",
-                "command-line-tool": "^0.8.0",
+                "command-line-args": "^6.0.1",
+                "command-line-usage": "^7.0.3",
                 "config-master": "^3.1.0",
-                "dmd": "^6.2.3",
-                "jsdoc-api": "^8.1.1",
-                "jsdoc-parse": "^6.2.1",
-                "walk-back": "^5.1.0"
+                "dmd": "^7.1.1",
+                "jsdoc-api": "^9.3.5",
+                "jsdoc-parse": "^6.2.5",
+                "walk-back": "^5.1.1"
             }
         },
         "json-buffer": {
@@ -7095,18 +6667,6 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "lodash.omit": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-            "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-            "dev": true
-        },
-        "lodash.padend": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-            "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
             "dev": true
         },
         "magic-string": {
@@ -7248,12 +6808,6 @@
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true
         },
-        "mkdirp2": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.5.tgz",
-            "integrity": "sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==",
-            "dev": true
-        },
         "moment": {
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -7298,12 +6852,6 @@
             "requires": {
                 "path-key": "^3.0.0"
             }
-        },
-        "object-get": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.1.tgz",
-            "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==",
-            "dev": true
         },
         "object-to-spawn-args": {
             "version": "2.0.1",
@@ -7523,48 +7071,6 @@
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                     "dev": true
-                }
-            }
-        },
-        "reduce-flatten": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.1.tgz",
-            "integrity": "sha512-bYo+97BmUUOzg09XwfkwALt4PQH1M5L0wzKerBt6WLm3Fhdd43mMS89HiT1B9pJIqko/6lWx3OnV4J9f2Kqp5Q==",
-            "dev": true
-        },
-        "reduce-unique": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz",
-            "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==",
-            "dev": true
-        },
-        "reduce-without": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-            "integrity": "sha512-zQv5y/cf85sxvdrKPlfcRzlDn/OqKFThNimYmsS3flmkioKvkUGn2Qg9cJVoQiEvdxFGLE0MQER/9fZ9sUqdxg==",
-            "dev": true,
-            "requires": {
-                "test-value": "^2.0.0"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-                    "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-                    "dev": true,
-                    "requires": {
-                        "typical": "^2.6.0"
-                    }
-                },
-                "test-value": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-                    "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
-                    "dev": true,
-                    "requires": {
-                        "array-back": "^1.0.3",
-                        "typical": "^2.6.0"
-                    }
                 }
             }
         },
@@ -7865,21 +7371,13 @@
             "dev": true
         },
         "sort-array": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.0.0.tgz",
-            "integrity": "sha512-Sg9MzajSGprcSrMIxsXyNT0e0JB47RJRfJspC+7co4Z5BdNsNl8FmWI+lXEpyKq+vkMG6pHgAhqyCO+bkDTfFQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.1.1.tgz",
+            "integrity": "sha512-EltS7AIsNlAFIM9cayrgKrM6XP94ATWwXP4LCL4IQbvbYhELSt2hZTrixg+AaQwnWFs/JGJgqU3rxMcNNWxGAA==",
             "dev": true,
             "requires": {
                 "array-back": "^6.2.2",
                 "typical": "^7.1.1"
-            },
-            "dependencies": {
-                "typical": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/typical/-/typical-7.2.0.tgz",
-                    "integrity": "sha512-W1+HdVRUl8fS3MZ9ogD51GOb46xMmhAZzR0WPw5jcgIZQJVvkddYzAl4YTU6g5w33Y1iRQLdIi2/1jhi2RNL0g==",
-                    "dev": true
-                }
             }
         },
         "source-map": {
@@ -7968,36 +7466,10 @@
                 "escodegen": "^2.1.0"
             }
         },
-        "stream-connect": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-            "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
-            "dev": true,
-            "requires": {
-                "array-back": "^1.0.2"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-                    "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-                    "dev": true,
-                    "requires": {
-                        "typical": "^2.6.0"
-                    }
-                }
-            }
-        },
         "stream-shift": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
             "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-            "dev": true
-        },
-        "stream-via": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-            "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
             "dev": true
         },
         "string_decoder": {
@@ -8082,54 +7554,13 @@
             "dev": true
         },
         "table-layout": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-            "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+            "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
             "dev": true,
             "requires": {
-                "array-back": "^2.0.0",
-                "deep-extend": "~0.6.0",
-                "lodash.padend": "^4.6.1",
-                "typical": "^2.6.1",
-                "wordwrapjs": "^3.0.0"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-                    "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-                    "dev": true,
-                    "requires": {
-                        "typical": "^2.6.1"
-                    }
-                }
-            }
-        },
-        "temp-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-            "integrity": "sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==",
-            "dev": true
-        },
-        "test-value": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-            "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-            "dev": true,
-            "requires": {
-                "array-back": "^2.0.0",
-                "typical": "^2.6.1"
-            },
-            "dependencies": {
-                "array-back": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-                    "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-                    "dev": true,
-                    "requires": {
-                        "typical": "^2.6.1"
-                    }
-                }
+                "array-back": "^6.2.2",
+                "wordwrapjs": "^5.1.0"
             }
         },
         "through2": {
@@ -8141,12 +7572,6 @@
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
             }
-        },
-        "to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "dev": true
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -8191,9 +7616,9 @@
             "dev": true
         },
         "typical": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-            "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+            "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
             "dev": true
         },
         "uc.micro": {
@@ -8259,10 +7684,11 @@
             "dev": true
         },
         "walk-back": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.1.tgz",
-            "integrity": "sha512-e/FRLDVdZQWFrAzU6Hdvpm7D7m2ina833gIKLptQykRK49mmCYHLHq7UqjPDbxbKLZkTkW1rFqbengdE3sLfdw==",
-            "dev": true
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.2.tgz",
+            "integrity": "sha512-uCgzIY1U7fyXvJm+mesY0xjf2HXu7mtTnptONwVQ11ur1JhMrUyQJn2fDje1CGFQDnTFTo1Slr1vRuvUS9PYoQ==",
+            "dev": true,
+            "requires": {}
         },
         "which": {
             "version": "2.0.2",
@@ -8295,22 +7721,10 @@
             "dev": true
         },
         "wordwrapjs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-            "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-            "dev": true,
-            "requires": {
-                "reduce-flatten": "^1.0.1",
-                "typical": "^2.6.1"
-            },
-            "dependencies": {
-                "reduce-flatten": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-                    "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
-                    "dev": true
-                }
-            }
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+            "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+            "dev": true
         },
         "wrap-ansi": {
             "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "build": "rollup -c",
         "watch": "rollup -cw",
         "prepublishOnly": "npm run build && npm run build_docs",
-        "build_docs": "jsdoc2md source/gltf-sample-renderer.js source/GltfView/gltf_view.js source/GltfState/gltf_state.js source/ResourceLoader/resource_loader.js source/gltf/user_camera.js > API.md",
+        "build_docs": "jsdoc2md source/gltf-sample-renderer.js source/GltfView/gltf_view.js source/GltfState/gltf_state.js source/ResourceLoader/resource_loader.js source/gltf/user_camera.js source/ResourceLoader/loader_utils.js > API.md",
         "test": "echo \"Error: no test specified\" && exit 1",
         "lint": "eslint source/**/*.js",
         "lint:fix": "eslint --fix source/**/*.js",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "concurrently": "^8.2.2",
         "eslint": "^9.5.0",
         "eslint-config-prettier": "^10.1.8",
-        "jsdoc-to-markdown": "^8.0.1",
+        "jsdoc-to-markdown": "^9.1.3",
         "prettier": "3.6.2",
         "rollup": "^4.23.0",
         "rollup-plugin-copy": "^3.5.0",

--- a/source/GltfView/gltf_view.js
+++ b/source/GltfView/gltf_view.js
@@ -87,7 +87,12 @@ class GltfView {
      */
     gatherStatistics(state) {
         if (state.gltf === undefined) {
-            return;
+            return {
+                meshCount: 0,
+                faceCount: 0,
+                opaqueMaterialsCount: 0,
+                transparentMaterialsCount: 0
+            };
         }
 
         // gather information from the active scene

--- a/source/ResourceLoader/loader.js
+++ b/source/ResourceLoader/loader.js
@@ -1,12 +1,21 @@
 class gltfLoader {
-    static async load(gltf, webGlContext, appendix = undefined) {
+    static async load(gltf, webGlContext, appendix = undefined, allowResourceAbsolutePath = true) {
         const buffers = gltfLoader.getBuffers(appendix);
         const additionalFiles = gltfLoader.getAdditionalFiles(appendix);
 
-        const buffersPromise = gltfLoader.loadBuffers(gltf, buffers, additionalFiles);
+        const buffersPromise = gltfLoader.loadBuffers(
+            gltf,
+            buffers,
+            additionalFiles,
+            allowResourceAbsolutePath
+        );
 
         await buffersPromise; // images might be stored in the buffers
-        const imagesPromise = gltfLoader.loadImages(gltf, additionalFiles);
+        const imagesPromise = gltfLoader.loadImages(
+            gltf,
+            additionalFiles,
+            allowResourceAbsolutePath
+        );
 
         return await Promise.all([buffersPromise, imagesPromise]).then(() =>
             gltf.initGl(webGlContext)
@@ -50,7 +59,7 @@ class gltfLoader {
         }
     }
 
-    static loadBuffers(gltf, buffers, additionalFiles) {
+    static loadBuffers(gltf, buffers, additionalFiles, allowResourceAbsolutePath) {
         const promises = [];
 
         if (buffers !== undefined && buffers[0] !== undefined) {
@@ -63,20 +72,22 @@ class gltfLoader {
 
             gltf.buffers[0].buffer = buffers[0];
             for (let i = 1; i < gltf.buffers.length; ++i) {
-                promises.push(gltf.buffers[i].load(gltf, additionalFiles));
+                promises.push(
+                    gltf.buffers[i].load(gltf, additionalFiles, allowResourceAbsolutePath)
+                );
             }
         } else {
             for (const buffer of gltf.buffers) {
-                promises.push(buffer.load(gltf, additionalFiles));
+                promises.push(buffer.load(gltf, additionalFiles, allowResourceAbsolutePath));
             }
         }
         return Promise.all(promises);
     }
 
-    static loadImages(gltf, additionalFiles) {
+    static loadImages(gltf, additionalFiles, allowResourceAbsolutePath) {
         const imagePromises = [];
         for (let image of gltf.images) {
-            imagePromises.push(image.load(gltf, additionalFiles));
+            imagePromises.push(image.load(gltf, additionalFiles, allowResourceAbsolutePath));
         }
         return Promise.all(imagePromises);
     }

--- a/source/ResourceLoader/loader_utils.js
+++ b/source/ResourceLoader/loader_utils.js
@@ -1,0 +1,69 @@
+/**
+ * Utility class providing static helper methods for resource loading operations,
+ * such as extracting file extensions, resolving folder paths, normalizing relative
+ * paths, and detecting absolute URLs.
+ */
+class ResourceLoaderUtils {
+    /**
+     * Extracts the file extension from a filename.
+     * @param {string} filename - The filename or path to extract the extension from.
+     * @returns {string|undefined} The lowercase file extension (without the leading dot),
+     *   or `undefined` if the filename has no extension.
+     */
+    static getExtension(filename) {
+        const split = filename.toLowerCase().split(".");
+        if (split.length == 1) {
+            return undefined;
+        }
+        return split[split.length - 1];
+    }
+
+    /**
+     * Returns the directory portion of a file path, including the trailing slash.
+     * @param {string} filePath - The full file path.
+     * @returns {string} The path up to and including the last `/`, or an empty string
+     *   if no `/` is present.
+     */
+    static getContainingFolder(filePath) {
+        return filePath.substring(0, filePath.lastIndexOf("/") + 1);
+    }
+
+    /**
+     * Normalizes a relative URL path by resolving `.` and `..` segments.
+     * - Strips a leading `./` prefix.
+     * - Collapses `/./` sequences to `/`.
+     * - Resolves `/../` sequences by removing the preceding path segment.
+     * @param {string} relativePath - The relative path to clean.
+     * @returns {string} The normalized path with dot segments resolved.
+     */
+    static cleanRelativePath(relativePath) {
+        if (relativePath.startsWith("./")) {
+            relativePath = relativePath.substring(2);
+        }
+        while (relativePath.includes("/./")) {
+            relativePath = relativePath.replace("/./", "/");
+        }
+        let searchIndex = relativePath.indexOf("/../");
+        while (searchIndex !== -1) {
+            let slashIndex = relativePath.lastIndexOf("/", searchIndex - 1);
+            relativePath =
+                relativePath.substring(0, slashIndex + 1) + relativePath.substring(searchIndex + 4);
+            searchIndex = relativePath.indexOf("/../");
+        }
+        return relativePath;
+    }
+
+    /**
+     * Determines whether a URL is absolute (i.e. contains a scheme such as `http:` or `data:`).
+     * A URL is considered absolute when it contains a `:` that appears before any `/`.
+     * @param {string} url - The URL string to test.
+     * @returns {boolean} `true` if the URL is absolute, `false` otherwise.
+     */
+    static isAbsoluteUrl(url) {
+        const colonIndex = url.indexOf(":");
+        const slashIndex = url.indexOf("/");
+        return colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex);
+    }
+}
+
+export { ResourceLoaderUtils };

--- a/source/ResourceLoader/resource_loader.js
+++ b/source/ResourceLoader/resource_loader.js
@@ -75,7 +75,7 @@ class ResourceLoader {
             gltfFile[1] instanceof File
         ) {
             let fileContent = gltfFile[1];
-            filename = gltfFile[1].name;
+            filename = gltfFile[0];
             isGlb = getIsGlb(filename);
             if (isGlb) {
                 data = await AsyncFileReader.readAsArrayBuffer(fileContent);

--- a/source/ResourceLoader/resource_loader.js
+++ b/source/ResourceLoader/resource_loader.js
@@ -39,9 +39,10 @@ class ResourceLoader {
      * loadGltf asynchroneously and create resources for rendering
      * @param {(String | ArrayBuffer | File)} gltfFile the .gltf or .glb file either as path or as preloaded resource. In node.js environments, only ArrayBuffer types are accepted.
      * @param {File[]} [externalFiles] additional files containing resources that are referenced in the gltf
+     * @param {Boolean} allowResourceAbsolutePath whether to allow absolute paths for images/buffers.
      * @returns {Promise} a promise that fulfills when the gltf file was loaded
      */
-    async loadGltf(gltfFile, externalFiles) {
+    async loadGltf(gltfFile, externalFiles, allowResourceAbsolutePath = true) {
         let isGlb = undefined;
         let buffers = undefined;
         let json = undefined;
@@ -104,13 +105,8 @@ class ResourceLoader {
         //Make sure draco decoder instance is ready
         gltf.fromJson(json);
 
-        // because the gltf image paths are not relative
-        // to the gltf, we have to resolve all image paths before that
-        for (const image of gltf.images) {
-            image.resolveRelativePath(getContainingFolder(gltf.path));
-        }
         await init(`${this.libPath}mikktspace_bg.wasm`);
-        await gltfLoader.load(gltf, this.view.context, buffers);
+        await gltfLoader.load(gltf, this.view.context, buffers, allowResourceAbsolutePath);
 
         return gltf;
     }

--- a/source/ResourceLoader/resource_loader.js
+++ b/source/ResourceLoader/resource_loader.js
@@ -1,5 +1,4 @@
 import { glTF } from "../gltf/gltf.js";
-import { getIsGlb, getContainingFolder } from "../gltf/utils.js";
 import { GlbParser } from "./glb_parser.js";
 import { gltfLoader } from "./loader.js";
 import { gltfImage, ImageMimeType } from "../gltf/image.js";
@@ -16,6 +15,8 @@ import { DracoDecoder } from "./draco.js";
 import { KtxDecoder } from "./ktx.js";
 
 import { loadHDR } from "../libs/hdrpng.js";
+
+import { ResourceLoaderUtils } from "./loader_utils.js";
 
 /**
  * ResourceLoader can be used to load resources for the GltfState
@@ -76,7 +77,7 @@ class ResourceLoader {
         ) {
             let fileContent = gltfFile[1];
             filename = gltfFile[0];
-            isGlb = getIsGlb(filename);
+            isGlb = ResourceLoaderUtils.getExtension(filename) == "glb";
             if (isGlb) {
                 data = await AsyncFileReader.readAsArrayBuffer(fileContent);
             } else {
@@ -130,7 +131,7 @@ class ResourceLoader {
             });
             image = await loadHDR(new Uint8Array(imageData));
         } else {
-            console.error("Passed invalid type to loadEnvironment " + typeof gltfFile);
+            console.error("Passed invalid type to loadEnvironment " + typeof environmentFile);
         }
         if (image === undefined) {
             return undefined;

--- a/source/gltf-sample-renderer.js
+++ b/source/gltf-sample-renderer.js
@@ -4,4 +4,6 @@ import { GltfState } from "./GltfState/gltf_state.js";
 
 import { ResourceLoader } from "./ResourceLoader/resource_loader.js";
 
-export { GltfView, GltfState, ResourceLoader };
+import { ResourceLoaderUtils } from "./ResourceLoader/loader_utils.js";
+
+export { GltfView, GltfState, ResourceLoader, ResourceLoaderUtils };

--- a/source/gltf/buffer.js
+++ b/source/gltf/buffer.js
@@ -1,4 +1,4 @@
-import { cleanRelativePath, getContainingFolder } from "./utils.js";
+import { cleanRelativePath, getContainingFolder, isAbsoluteUrl } from "./utils.js";
 import { GltfObject } from "./gltf_object.js";
 import { hasMeshOptCompression } from "./extension_utils.js";
 
@@ -23,7 +23,7 @@ class gltfBuffer extends GltfObject {
         const self = this;
         return new Promise(function (resolve, reject) {
             if (
-                !self.setBufferFromFiles(additionalFiles, resolve) &&
+                !self.setBufferFromFiles(gltf, additionalFiles, resolve) &&
                 !self.setBufferFromUri(gltf, resolve, reject, allowResourceAbsolutePath)
             ) {
                 if (hasMeshOptCompression(self)) {
@@ -41,13 +41,9 @@ class gltfBuffer extends GltfObject {
         if (this.uri === undefined) {
             return false;
         }
-        if (!allowResourceAbsolutePath) {
-            const colonIndex = this.uri.indexOf(":");
-            const slashIndex = this.uri.indexOf("/");
-            if (colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex)) {
-                reject("Absolute URLs are not allowed for security reasons: " + this.uri);
-                return true; // we return true, because the buffer has a uri, but we reject the loading due to security reasons
-            }
+        if (!allowResourceAbsolutePath && isAbsoluteUrl(this.uri)) {
+            reject("Absolute URLs are not allowed for security reasons: " + this.uri);
+            return true; // we return true, because the buffer has a uri, but we reject the loading due to security reasons
         }
         const parentPath = this.uri.startsWith("data:") ? "" : getContainingFolder(gltf.path ?? "");
         fetch(parentPath + this.uri)
@@ -70,14 +66,21 @@ class gltfBuffer extends GltfObject {
         return true;
     }
 
-    setBufferFromFiles(files, callback) {
+    setBufferFromFiles(gltf, files, callback) {
         if (this.uri === undefined || files === undefined) {
             return false;
         }
-        const cleanURI = cleanRelativePath(this.uri);
-        const foundFile = files.find(
-            (file) => file[1].name === cleanURI || file[1].fullPath === cleanURI
-        );
+        let actualPath = this.uri;
+        if (!isAbsoluteUrl(this.uri)) {
+            const parentPath = getContainingFolder(gltf.path ?? "");
+            actualPath = cleanRelativePath(parentPath + this.uri);
+        }
+
+        const foundFile = files.find((file) => {
+            if (file[0] == actualPath) {
+                return true;
+            }
+        });
 
         if (foundFile === undefined) {
             return false;

--- a/source/gltf/buffer.js
+++ b/source/gltf/buffer.js
@@ -1,6 +1,6 @@
-import { cleanRelativePath, getContainingFolder, isAbsoluteUrl } from "./utils.js";
 import { GltfObject } from "./gltf_object.js";
 import { hasMeshOptCompression } from "./extension_utils.js";
+import { ResourceLoaderUtils } from "../ResourceLoader/loader_utils.js";
 
 class gltfBuffer extends GltfObject {
     static animatedProperties = [];
@@ -41,11 +41,13 @@ class gltfBuffer extends GltfObject {
         if (this.uri === undefined) {
             return false;
         }
-        if (!allowResourceAbsolutePath && isAbsoluteUrl(this.uri)) {
+        if (!allowResourceAbsolutePath && ResourceLoaderUtils.isAbsoluteUrl(this.uri)) {
             reject("Absolute URLs are not allowed for security reasons: " + this.uri);
             return true; // we return true, because the buffer has a uri, but we reject the loading due to security reasons
         }
-        const parentPath = this.uri.startsWith("data:") ? "" : getContainingFolder(gltf.path ?? "");
+        const parentPath = this.uri.startsWith("data:")
+            ? ""
+            : ResourceLoaderUtils.getContainingFolder(gltf.path ?? "");
         fetch(parentPath + this.uri)
             .then((response) => {
                 if (!response.ok) {
@@ -71,9 +73,9 @@ class gltfBuffer extends GltfObject {
             return false;
         }
         let actualPath = this.uri;
-        if (!isAbsoluteUrl(this.uri)) {
-            const parentPath = getContainingFolder(gltf.path ?? "");
-            actualPath = cleanRelativePath(parentPath + this.uri);
+        if (!ResourceLoaderUtils.isAbsoluteUrl(this.uri)) {
+            const parentPath = ResourceLoaderUtils.getContainingFolder(gltf.path ?? "");
+            actualPath = ResourceLoaderUtils.cleanRelativePath(parentPath + this.uri);
         }
 
         const foundFile = files.find((file) => {

--- a/source/gltf/buffer.js
+++ b/source/gltf/buffer.js
@@ -1,4 +1,4 @@
-import { getContainingFolder } from "./utils.js";
+import { cleanRelativePath, getContainingFolder } from "./utils.js";
 import { GltfObject } from "./gltf_object.js";
 import { hasMeshOptCompression } from "./extension_utils.js";
 
@@ -14,7 +14,7 @@ class gltfBuffer extends GltfObject {
         this.buffer = undefined; // raw data blob
     }
 
-    load(gltf, additionalFiles = undefined) {
+    load(gltf, additionalFiles = undefined, allowResourceAbsolutePath = true) {
         if (this.buffer !== undefined) {
             console.error("buffer has already been loaded");
             return;
@@ -24,37 +24,48 @@ class gltfBuffer extends GltfObject {
         return new Promise(function (resolve, reject) {
             if (
                 !self.setBufferFromFiles(additionalFiles, resolve) &&
-                !self.setBufferFromUri(gltf, resolve, reject)
+                !self.setBufferFromUri(gltf, resolve, reject, allowResourceAbsolutePath)
             ) {
                 if (hasMeshOptCompression(self)) {
                     // buffer will be loaded by EXT_meshopt_compression or KHR_meshopt_compression
                     resolve();
                 } else {
                     // if buffer has no meshopt compression extension AND no uri or files provided, we have an error
-                    console.error("Was not able to resolve buffer with uri '%s'", self.uri);
                     reject("Buffer data missing for '" + self.name + "' in " + gltf.path);
                 }
             }
         });
     }
 
-    setBufferFromUri(gltf, resolve, reject) {
+    setBufferFromUri(gltf, resolve, reject, allowResourceAbsolutePath) {
         if (this.uri === undefined) {
             return false;
         }
-        const parentPath = this.uri.startsWith("data:") ? "" : getContainingFolder(gltf.path);
-        fetch(parentPath + this.uri).then((response) => {
-            if (!response.ok) {
-                reject(
-                    `Failed to fetch buffer from ${parentPath + this.uri}: ${response.statusText}`
-                );
-                return;
+        if (!allowResourceAbsolutePath) {
+            const colonIndex = this.uri.indexOf(":");
+            const slashIndex = this.uri.indexOf("/");
+            if (colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex)) {
+                reject("Absolute URLs are not allowed for security reasons: " + this.uri);
+                return true; // we return true, because the buffer has a uri, but we reject the loading due to security reasons
             }
-            response.arrayBuffer().then((buffer) => {
-                this.buffer = buffer;
-                resolve();
+        }
+        const parentPath = this.uri.startsWith("data:") ? "" : getContainingFolder(gltf.path ?? "");
+        fetch(parentPath + this.uri)
+            .then((response) => {
+                if (!response.ok) {
+                    reject(
+                        `Failed to fetch buffer from ${parentPath + this.uri}: ${response.statusText}`
+                    );
+                    return;
+                }
+                response.arrayBuffer().then((buffer) => {
+                    this.buffer = buffer;
+                    resolve();
+                });
+            })
+            .catch((error) => {
+                reject(`Error fetching buffer from ${parentPath + this.uri}: ${error}`);
             });
-        });
 
         return true;
     }
@@ -63,9 +74,9 @@ class gltfBuffer extends GltfObject {
         if (this.uri === undefined || files === undefined) {
             return false;
         }
-
+        const cleanURI = cleanRelativePath(this.uri);
         const foundFile = files.find(
-            (file) => file[1].name === this.uri || file[1].fullPath === this.uri
+            (file) => file[1].name === cleanURI || file[1].fullPath === cleanURI
         );
 
         if (foundFile === undefined) {

--- a/source/gltf/image.js
+++ b/source/gltf/image.js
@@ -1,5 +1,5 @@
 import { GltfObject } from "./gltf_object.js";
-import { getExtension } from "./utils.js";
+import { cleanRelativePath, getContainingFolder, getExtension } from "./utils.js";
 import { AsyncFileReader } from "../ResourceLoader/async_file_reader.js";
 import { GL } from "../Renderer/webgl";
 import { ImageMimeType } from "./image_mime_type.js";
@@ -27,19 +27,7 @@ class gltfImage extends GltfObject {
         this.miplevel = miplevel; // nonstandard
     }
 
-    resolveRelativePath(basePath) {
-        if (typeof this.uri === "string" || this.uri instanceof String) {
-            if (this.uri.startsWith("data:")) {
-                return;
-            }
-            if (this.uri.startsWith("./")) {
-                this.uri = this.uri.substring(2);
-            }
-            this.uri = basePath + this.uri;
-        }
-    }
-
-    async load(gltf, additionalFiles = undefined) {
+    async load(gltf, additionalFiles = undefined, allowResourceAbsolutePath) {
         if (this.image !== undefined) {
             if (this.mimeType !== ImageMimeType.GLTEXTURE) {
                 console.error("image has already been loaded");
@@ -50,7 +38,7 @@ class gltfImage extends GltfObject {
         if (
             !(await this.setImageFromBufferView(gltf)) &&
             !(await this.setImageFromFiles(gltf, additionalFiles)) &&
-            !(await this.setImageFromUri(gltf)) &&
+            !(await this.setImageFromUri(gltf, allowResourceAbsolutePath)) &&
             !(await this.setImageFromBase64(gltf))
         ) {
             return;
@@ -147,17 +135,26 @@ class gltfImage extends GltfObject {
         return await this.setImageFromBytes(gltf, new Uint8Array(buffer));
     }
 
-    async setImageFromUri(gltf) {
+    async setImageFromUri(gltf, allowResourceAbsolutePath) {
         if (this.uri === undefined || this.uri.startsWith("data:")) {
             return false;
         }
+        if (!allowResourceAbsolutePath) {
+            const colonIndex = this.uri.indexOf(":");
+            const slashIndex = this.uri.indexOf("/");
+            if (colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex)) {
+                throw new Error("Absolute URLs are not allowed for security reasons: " + this.uri);
+            }
+        }
+        const parentPath = getContainingFolder(gltf.path ?? "");
+        const fullPath = parentPath + this.uri;
         if (this.mimeType === undefined) {
             this.setMimetypeFromFilename(this.uri);
         }
 
         if (this.mimeType === ImageMimeType.KTX2) {
             if (gltf.ktxDecoder !== undefined) {
-                this.image = await gltf.ktxDecoder.loadKtxFromUri(this.uri);
+                this.image = await gltf.ktxDecoder.loadKtxFromUri(fullPath);
             } else {
                 console.warn("Loading of ktx images failed: KtxDecoder not initalized");
             }
@@ -168,9 +165,9 @@ class gltfImage extends GltfObject {
                 this.mimeType === ImageMimeType.WEBP)
         ) {
             try {
-                this.image = await gltfImage.loadHTMLImage(this.uri);
+                this.image = await gltfImage.loadHTMLImage(fullPath);
             } catch {
-                throw new Error(`Could not load image from ${this.uri}`);
+                throw new Error(`Could not load image from ${fullPath}`);
             }
         } else if (this.mimeType === ImageMimeType.JPEG && this.uri instanceof ArrayBuffer) {
             this.image = jpeg.decode(this.uri, { useTArray: true });
@@ -199,9 +196,9 @@ class gltfImage extends GltfObject {
         if (this.uri === undefined || files === undefined) {
             return false;
         }
-
+        const cleanURI = cleanRelativePath(this.uri);
         let foundFile = files.find((file) => {
-            if (file[0] == "/" + this.uri) {
+            if (file[0] == "/" + cleanURI) {
                 return true;
             }
         });

--- a/source/gltf/image.js
+++ b/source/gltf/image.js
@@ -1,5 +1,5 @@
 import { GltfObject } from "./gltf_object.js";
-import { cleanRelativePath, getContainingFolder, getExtension } from "./utils.js";
+import { cleanRelativePath, getContainingFolder, getExtension, isAbsoluteUrl } from "./utils.js";
 import { AsyncFileReader } from "../ResourceLoader/async_file_reader.js";
 import { GL } from "../Renderer/webgl";
 import { ImageMimeType } from "./image_mime_type.js";
@@ -139,12 +139,8 @@ class gltfImage extends GltfObject {
         if (this.uri === undefined || this.uri.startsWith("data:")) {
             return false;
         }
-        if (!allowResourceAbsolutePath) {
-            const colonIndex = this.uri.indexOf(":");
-            const slashIndex = this.uri.indexOf("/");
-            if (colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex)) {
-                throw new Error("Absolute URLs are not allowed for security reasons: " + this.uri);
-            }
+        if (!allowResourceAbsolutePath && isAbsoluteUrl(this.uri)) {
+            throw new Error("Absolute URLs are not allowed for security reasons: " + this.uri);
         }
         const parentPath = getContainingFolder(gltf.path ?? "");
         const fullPath = parentPath + this.uri;
@@ -196,9 +192,14 @@ class gltfImage extends GltfObject {
         if (this.uri === undefined || files === undefined) {
             return false;
         }
-        const cleanURI = cleanRelativePath(this.uri);
+        let actualPath = this.uri;
+        if (!isAbsoluteUrl(this.uri)) {
+            const parentPath = getContainingFolder(gltf.path ?? "");
+            actualPath = cleanRelativePath(parentPath + this.uri);
+        }
+
         let foundFile = files.find((file) => {
-            if (file[0] == "/" + cleanURI) {
+            if (file[0] == actualPath) {
                 return true;
             }
         });

--- a/source/gltf/image.js
+++ b/source/gltf/image.js
@@ -1,10 +1,10 @@
 import { GltfObject } from "./gltf_object.js";
-import { cleanRelativePath, getContainingFolder, getExtension, isAbsoluteUrl } from "./utils.js";
 import { AsyncFileReader } from "../ResourceLoader/async_file_reader.js";
 import { GL } from "../Renderer/webgl";
 import { ImageMimeType } from "./image_mime_type.js";
 import * as jpeg from "jpeg-js";
 import * as png from "fast-png";
+import { ResourceLoaderUtils } from "../ResourceLoader/loader_utils.js";
 
 class gltfImage extends GltfObject {
     static animatedProperties = [];
@@ -58,7 +58,7 @@ class gltfImage extends GltfObject {
     }
 
     setMimetypeFromFilename(filename) {
-        let extension = getExtension(filename);
+        let extension = ResourceLoaderUtils.getExtension(filename);
         if (extension == "ktx2" || extension == "ktx") {
             this.mimeType = ImageMimeType.KTX2;
         } else if (extension == "jpg" || extension == "jpeg") {
@@ -139,10 +139,10 @@ class gltfImage extends GltfObject {
         if (this.uri === undefined || this.uri.startsWith("data:")) {
             return false;
         }
-        if (!allowResourceAbsolutePath && isAbsoluteUrl(this.uri)) {
+        if (!allowResourceAbsolutePath && ResourceLoaderUtils.isAbsoluteUrl(this.uri)) {
             throw new Error("Absolute URLs are not allowed for security reasons: " + this.uri);
         }
-        const parentPath = getContainingFolder(gltf.path ?? "");
+        const parentPath = ResourceLoaderUtils.getContainingFolder(gltf.path ?? "");
         const fullPath = parentPath + this.uri;
         if (this.mimeType === undefined) {
             this.setMimetypeFromFilename(this.uri);
@@ -193,9 +193,9 @@ class gltfImage extends GltfObject {
             return false;
         }
         let actualPath = this.uri;
-        if (!isAbsoluteUrl(this.uri)) {
-            const parentPath = getContainingFolder(gltf.path ?? "");
-            actualPath = cleanRelativePath(parentPath + this.uri);
+        if (!ResourceLoaderUtils.isAbsoluteUrl(this.uri)) {
+            const parentPath = ResourceLoaderUtils.getContainingFolder(gltf.path ?? "");
+            actualPath = ResourceLoaderUtils.cleanRelativePath(parentPath + this.uri);
         }
 
         let foundFile = files.find((file) => {

--- a/source/gltf/utils.js
+++ b/source/gltf/utils.js
@@ -100,69 +100,6 @@ function clamp(number, min, max) {
     return Math.min(Math.max(number, min), max);
 }
 
-function getIsGlb(filename) {
-    return getExtension(filename) == "glb";
-}
-
-function getIsGltf(filename) {
-    return getExtension(filename) == "gltf";
-}
-
-function getIsHdr(filename) {
-    return getExtension(filename) == "hdr";
-}
-
-function getExtension(filename) {
-    const split = filename.toLowerCase().split(".");
-    if (split.length == 1) {
-        return undefined;
-    }
-    return split[split.length - 1];
-}
-
-function getFileName(filePath) {
-    const split = filePath.split("/");
-    return split[split.length - 1];
-}
-
-function getFileNameWithoutExtension(filePath) {
-    const filename = getFileName(filePath);
-    const index = filename.lastIndexOf(".");
-    return filename.slice(0, index);
-}
-
-function getContainingFolder(filePath) {
-    return filePath.substring(0, filePath.lastIndexOf("/") + 1);
-}
-
-function combinePaths() {
-    const parts = Array.from(arguments);
-    return parts.join("/");
-}
-
-function cleanRelativePath(relativePath) {
-    if (relativePath.startsWith("./")) {
-        relativePath = relativePath.substring(2);
-    }
-    while (relativePath.includes("/./")) {
-        relativePath = relativePath.replace("/./", "/");
-    }
-    let searchIndex = relativePath.indexOf("/../");
-    while (searchIndex !== -1) {
-        let slashIndex = relativePath.lastIndexOf("/", searchIndex - 1);
-        relativePath =
-            relativePath.substring(0, slashIndex + 1) + relativePath.substring(searchIndex + 4);
-        searchIndex = relativePath.indexOf("/../");
-    }
-    return relativePath;
-}
-
-function isAbsoluteUrl(url) {
-    const colonIndex = url.indexOf(":");
-    const slashIndex = url.indexOf("/");
-    return colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex);
-}
-
 // marker interface used to for parsing the uniforms
 class UniformStruct {}
 
@@ -249,16 +186,6 @@ export {
     fromParams,
     stringHash,
     clamp,
-    getIsGlb,
-    getIsGltf,
-    getIsHdr,
-    getExtension,
-    getFileName,
-    getFileNameWithoutExtension,
-    getContainingFolder,
-    isAbsoluteUrl,
-    combinePaths,
-    cleanRelativePath,
     UniformStruct,
     Timer,
     AnimationTimer,

--- a/source/gltf/utils.js
+++ b/source/gltf/utils.js
@@ -140,6 +140,28 @@ function combinePaths() {
     return parts.join("/");
 }
 
+function cleanRelativePath(relativePath) {
+    if (relativePath.startsWith("./")) {
+        relativePath = relativePath.substring(2);
+    }
+    while (relativePath.includes("/./")) {
+        relativePath = relativePath.replace("/./", "/");
+    }
+    if (relativePath.startsWith("../")) {
+        throw new Error(
+            "Browser do not allow accessing files in parent directories " + relativePath
+        );
+    }
+    let searchIndex = relativePath.indexOf("/../");
+    while (searchIndex !== -1) {
+        let slashIndex = relativePath.lastIndexOf("/", searchIndex - 1);
+        relativePath =
+            relativePath.substring(0, slashIndex) + relativePath.substring(searchIndex + 4);
+        searchIndex = relativePath.indexOf("/../");
+    }
+    return relativePath;
+}
+
 // marker interface used to for parsing the uniforms
 class UniformStruct {}
 
@@ -234,6 +256,7 @@ export {
     getFileNameWithoutExtension,
     getContainingFolder,
     combinePaths,
+    cleanRelativePath,
     UniformStruct,
     Timer,
     AnimationTimer,

--- a/source/gltf/utils.js
+++ b/source/gltf/utils.js
@@ -147,19 +147,20 @@ function cleanRelativePath(relativePath) {
     while (relativePath.includes("/./")) {
         relativePath = relativePath.replace("/./", "/");
     }
-    if (relativePath.startsWith("../")) {
-        throw new Error(
-            "Browser do not allow accessing files in parent directories " + relativePath
-        );
-    }
     let searchIndex = relativePath.indexOf("/../");
     while (searchIndex !== -1) {
         let slashIndex = relativePath.lastIndexOf("/", searchIndex - 1);
         relativePath =
-            relativePath.substring(0, slashIndex) + relativePath.substring(searchIndex + 4);
+            relativePath.substring(0, slashIndex + 1) + relativePath.substring(searchIndex + 4);
         searchIndex = relativePath.indexOf("/../");
     }
     return relativePath;
+}
+
+function isAbsoluteUrl(url) {
+    const colonIndex = url.indexOf(":");
+    const slashIndex = url.indexOf("/");
+    return colonIndex !== -1 && (slashIndex === -1 || colonIndex < slashIndex);
 }
 
 // marker interface used to for parsing the uniforms
@@ -255,6 +256,7 @@ export {
     getFileName,
     getFileNameWithoutExtension,
     getContainingFolder,
+    isAbsoluteUrl,
     combinePaths,
     cleanRelativePath,
     UniformStruct,


### PR DESCRIPTION
Add option to ResourceLoader to disallow fetching of absolute URLs for sub-resources (URIs defined inside the JSON).
Absolute URLs will still be loaded if the binary files are supplied directly to the ResourceLoader.
This ensures that the renderer does not download/access files indirectly without the user's knowledge.
Improves error handling.
Export file path utility functions.

**This also changes the expected paths from the frontend. Previously, relative paths were expected to start with a / which is incorrect. Now the frontend needs to sanitize the paths correctly. (Relative paths can start with ./ ../ or without slash)**