### PR TITLE
Fix materials on meshes with physics transform

### DIFF
--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -1139,11 +1139,15 @@ class gltfRenderer {
         }
 
         const worldTransform = node.getRenderedWorldTransform();
+      
+        const normalMatrix = mat4.create();
+        mat4.invert(normalMatrix, node.getRenderedWorldTransform());
+        mat4.transpose(normalMatrix, normalMatrix);
 
         // update model dependant matrices once per node
         this.shader.updateUniform("u_ViewProjectionMatrix", viewProjectionMatrix);
         this.shader.updateUniform("u_ModelMatrix", worldTransform);
-        this.shader.updateUniform("u_NormalMatrix", node.normalMatrix, false);
+        this.shader.updateUniform("u_NormalMatrix", normalMatrix, false);
         this.shader.updateUniform("u_Exposure", state.renderingParameters.exposure, false);
         this.shader.updateUniform("u_Camera", this.currentCameraPosition, false);
         if (renderpassConfiguration.picking) {

--- a/source/gltf/node.js
+++ b/source/gltf/node.js
@@ -29,7 +29,6 @@ class gltfNode extends GltfObject {
         this.worldQuaternion = quat.create();
         this.worldScale = vec3.create();
         this.inverseWorldTransform = mat4.create();
-        this.normalMatrix = mat4.create();
         this.light = undefined;
         this.instanceMatrices = undefined;
         this.instanceWorldTransforms = undefined;

--- a/source/gltf/scene.js
+++ b/source/gltf/scene.js
@@ -26,15 +26,15 @@ class gltfScene extends GltfObject {
             const nodeDirty = parentDirty || node.isLocalTransformDirty();
             node.dirtyTransform = nodeDirty;
             node.dirtyScale = false;
-
-            mat4.multiply(node.worldTransform, parentTransform, node.getLocalTransform());
-            mat4.invert(node.inverseWorldTransform, node.getRenderedWorldTransform());
-            mat4.transpose(node.normalMatrix, node.inverseWorldTransform);
-            quat.multiply(node.worldQuaternion, parentRotation, node.rotation);
-            mat4.getScaling(node.worldScale, node.getRenderedWorldTransform());
-
-            if (nodeDirty && (parentScaleDirty || node.animatedPropertyObjects["scale"].dirty)) {
-                node.dirtyScale = true;
+            if (nodeDirty) {
+                mat4.multiply(node.worldTransform, parentTransform, node.getLocalTransform());
+                mat4.invert(node.inverseWorldTransform, node.worldTransform);
+                mat4.transpose(node.normalMatrix, node.inverseWorldTransform);
+                quat.multiply(node.worldQuaternion, parentRotation, node.rotation);
+                mat4.getScaling(node.worldScale, node.worldTransform);
+                if (parentScaleDirty || node.animatedPropertyObjects["scale"].dirty) {
+                    node.dirtyScale = true;
+                }
             }
 
             if (nodeDirty && node.instanceMatrices) {
@@ -42,7 +42,7 @@ class gltfScene extends GltfObject {
                 for (let i = 0; i < node.instanceMatrices.length; i++) {
                     const instanceTransform = node.instanceMatrices[i];
                     const instanceWorldTransform = mat4.create();
-                    mat4.multiply(instanceWorldTransform, node.getRenderedWorldTransform(), instanceTransform);
+                    mat4.multiply(instanceWorldTransform, node.worldTransform, instanceTransform);
                     node.instanceWorldTransforms.push(instanceWorldTransform);
                 }
             }

--- a/source/gltf/scene.js
+++ b/source/gltf/scene.js
@@ -29,7 +29,6 @@ class gltfScene extends GltfObject {
             if (nodeDirty) {
                 mat4.multiply(node.worldTransform, parentTransform, node.getLocalTransform());
                 mat4.invert(node.inverseWorldTransform, node.worldTransform);
-                mat4.transpose(node.normalMatrix, node.inverseWorldTransform);
                 quat.multiply(node.worldQuaternion, parentRotation, node.rotation);
                 mat4.getScaling(node.worldScale, node.worldTransform);
                 if (parentScaleDirty || node.animatedPropertyObjects["scale"].dirty) {

--- a/source/gltf/scene.js
+++ b/source/gltf/scene.js
@@ -26,15 +26,15 @@ class gltfScene extends GltfObject {
             const nodeDirty = parentDirty || node.isLocalTransformDirty();
             node.dirtyTransform = nodeDirty;
             node.dirtyScale = false;
-            if (nodeDirty) {
-                mat4.multiply(node.worldTransform, parentTransform, node.getLocalTransform());
-                mat4.invert(node.inverseWorldTransform, node.worldTransform);
-                mat4.transpose(node.normalMatrix, node.inverseWorldTransform);
-                quat.multiply(node.worldQuaternion, parentRotation, node.rotation);
-                mat4.getScaling(node.worldScale, node.worldTransform);
-                if (parentScaleDirty || node.animatedPropertyObjects["scale"].dirty) {
-                    node.dirtyScale = true;
-                }
+
+            mat4.multiply(node.worldTransform, parentTransform, node.getLocalTransform());
+            mat4.invert(node.inverseWorldTransform, node.getRenderedWorldTransform());
+            mat4.transpose(node.normalMatrix, node.inverseWorldTransform);
+            quat.multiply(node.worldQuaternion, parentRotation, node.rotation);
+            mat4.getScaling(node.worldScale, node.getRenderedWorldTransform());
+
+            if (nodeDirty && (parentScaleDirty || node.animatedPropertyObjects["scale"].dirty)) {
+                node.dirtyScale = true;
             }
 
             if (nodeDirty && node.instanceMatrices) {
@@ -42,7 +42,7 @@ class gltfScene extends GltfObject {
                 for (let i = 0; i < node.instanceMatrices.length; i++) {
                     const instanceTransform = node.instanceMatrices[i];
                     const instanceWorldTransform = mat4.create();
-                    mat4.multiply(instanceWorldTransform, node.worldTransform, instanceTransform);
+                    mat4.multiply(instanceWorldTransform, node.getRenderedWorldTransform(), instanceTransform);
                     node.instanceWorldTransforms.push(instanceWorldTransform);
                 }
             }


### PR DESCRIPTION
Normal matrices have not been updated if the node's physics transform changed.

Fixes [#639](https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/639)
