### PR TITLE
Add support for KHR_materials_retroreflection

### DIFF
--- a/source/GltfState/gltf_state.js
+++ b/source/GltfState/gltf_state.js
@@ -95,6 +95,8 @@ class GltfState {
                 KHR_materials_dispersion: true,
                 /** KHR_materials_emissive_strength enables emissive factors larger than 1.0 */
                 KHR_materials_emissive_strength: true,
+                /** KHR_materials_retroreflection adds a retroreflective response to the metallic and dielectric BRDFs */
+                KHR_materials_retroreflection: true,
                 /** KHR_interactivity enables execution of a behavior graph */
                 KHR_interactivity: true,
                 /** KHR_node_hoverability enables hovering over nodes */
@@ -255,6 +257,12 @@ GltfState.DebugOutput = {
         IRIDESCENCE_FACTOR: "Iridescence Strength",
         /** output the iridescence thickness*/
         IRIDESCENCE_THICKNESS: "Iridescence Thickness"
+    },
+
+    /** KHR_materials_retroreflection */
+    retroreflection: {
+        /** output the retroreflection strength*/
+        RETROREFLECTION_FACTOR: "Retroreflection Strength"
     },
 
     /** KHR_materials_anisotropy */

--- a/source/Renderer/renderer.js
+++ b/source/Renderer/renderer.js
@@ -1882,6 +1882,9 @@ class gltfRenderer {
         this.shader.updateUniform("u_IridescenceThicknessUVSet", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessTexture?.texCoord);
         this.shader.updateUniform("u_IridescenceThicknessMinimum", material.extensions?.KHR_materials_iridescence?.iridescenceThicknessMinimum);
 
+        this.shader.updateUniform("u_RetroreflectionFactor", material.extensions?.KHR_materials_retroreflection?.retroreflectionFactor);
+        this.shader.updateUniform("u_RetroreflectionUVSet", material.extensions?.KHR_materials_retroreflection?.retroreflectionTexture?.texCoord);
+
         this.shader.updateUniform("u_SheenRoughnessFactor", material.extensions?.KHR_materials_sheen?.sheenRoughnessFactor);
         this.shader.updateUniform("u_SheenColorFactor", jsToGl(material.extensions?.KHR_materials_sheen?.sheenColorFactor));
         this.shader.updateUniform("u_SheenRoughnessUVSet", material.extensions?.KHR_materials_sheen?.sheenRoughnessTexture?.texCoord);
@@ -2220,6 +2223,11 @@ class gltfRenderer {
             {
                 debugOutput: GltfState.DebugOutput.iridescence.IRIDESCENCE_THICKNESS,
                 shaderDefine: "DEBUG_IRIDESCENCE_THICKNESS"
+            },
+
+            {
+                debugOutput: GltfState.DebugOutput.retroreflection.RETROREFLECTION_FACTOR,
+                shaderDefine: "DEBUG_RETROREFLECTION_FACTOR"
             },
 
             {

--- a/source/Renderer/shaders/material_info.glsl
+++ b/source/Renderer/shaders/material_info.glsl
@@ -29,6 +29,9 @@ uniform float u_IridescenceIor;
 uniform float u_IridescenceThicknessMinimum;
 uniform float u_IridescenceThicknessMaximum;
 
+// Retroreflection
+uniform float u_RetroreflectionFactor;
+
 // Diffuse Transmission
 uniform float u_DiffuseTransmissionFactor;
 uniform vec3 u_DiffuseTransmissionColorFactor;
@@ -101,6 +104,9 @@ struct MaterialInfo
     float iridescenceFactor;
     float iridescenceIor;
     float iridescenceThickness;
+
+    // KHR_materials_retroreflection
+    float retroreflectionFactor;
 
     float diffuseTransmissionFactor;
     vec3 diffuseTransmissionColorFactor;
@@ -322,6 +328,20 @@ MaterialInfo getIridescenceInfo(MaterialInfo info)
         float thicknessSampled = texture(u_IridescenceThicknessSampler, getIridescenceThicknessUV()).g;
         float thickness = mix(u_IridescenceThicknessMinimum, u_IridescenceThicknessMaximum, thicknessSampled);
         info.iridescenceThickness = thickness;
+    #endif
+
+    return info;
+}
+#endif
+
+
+#ifdef MATERIAL_RETROREFLECTION
+MaterialInfo getRetroreflectionInfo(MaterialInfo info)
+{
+    info.retroreflectionFactor = u_RetroreflectionFactor;
+
+    #ifdef HAS_RETROREFLECTION_MAP
+        info.retroreflectionFactor *= texture(u_RetroreflectionSampler, getRetroreflectionUV()).r;
     #endif
 
     return info;

--- a/source/Renderer/shaders/pbr.frag
+++ b/source/Renderer/shaders/pbr.frag
@@ -115,6 +115,10 @@ void main()
     materialInfo = getIridescenceInfo(materialInfo);
 #endif
 
+#ifdef MATERIAL_RETROREFLECTION
+    materialInfo = getRetroreflectionInfo(materialInfo);
+#endif
+
 #ifdef MATERIAL_DIFFUSE_TRANSMISSION
     materialInfo = getDiffuseTransmissionInfo(materialInfo);
 #endif
@@ -157,6 +161,14 @@ void main()
     if (materialInfo.iridescenceThickness == 0.0) {
         materialInfo.iridescenceFactor = 0.0;
     }
+#endif
+
+#ifdef MATERIAL_RETROREFLECTION
+    // Reflection of v about n (MRM model). Other extensions that modify the metallic/dielectric
+    // BRDF's specular direction or Fresnel color (anisotropy, iridescence) are re-applied below
+    // using v_retro, so the retroreflective lobe stays consistent with those extensions instead
+    // of silently reverting to the isotropic, non-iridescent base BRDF.
+    vec3 v_retro = normalize(reflect(-v, n));
 #endif
 
 #ifdef MATERIAL_DIFFUSE_TRANSMISSION
@@ -222,6 +234,29 @@ void main()
 #ifdef MATERIAL_IRIDESCENCE
     f_metal_brdf_ibl = mix(f_metal_brdf_ibl, f_specular_metal * iridescenceFresnel_metallic, materialInfo.iridescenceFactor);
     f_dielectric_brdf_ibl = mix(f_dielectric_brdf_ibl, rgb_mix(f_diffuse, f_specular_dielectric, iridescenceFresnel_dielectric), materialInfo.iridescenceFactor);
+#endif
+
+#ifdef MATERIAL_RETROREFLECTION
+    // Retroreflective variant of the metallic and dielectric BRDFs (MRM model): the specular
+    // lobe's view direction is substituted with v_retro. The Fresnel mix weight is unchanged
+    // because NdotV is invariant under the v -> v_retro substitution. Anisotropy's bent-normal
+    // reflection and iridescence's Fresnel tint are re-applied with v_retro so they compose
+    // correctly with retroreflection instead of being silently dropped from the retro lobe.
+#ifdef MATERIAL_ANISOTROPY
+    vec3 f_specular_retro = getIBLRadianceAnisotropy(n, v_retro, materialInfo.perceptualRoughness, materialInfo.anisotropyStrength, materialInfo.anisotropicB);
+#else
+    vec3 f_specular_retro = getIBLRadianceGGX(n, v_retro, materialInfo.perceptualRoughness);
+#endif
+    vec3 f_metal_brdf_retro = f_metal_fresnel_ibl * f_specular_retro;
+    vec3 f_dielectric_brdf_retro = mix(f_diffuse, f_specular_retro, f_dielectric_fresnel_ibl);
+
+#ifdef MATERIAL_IRIDESCENCE
+    f_metal_brdf_retro = mix(f_metal_brdf_retro, f_specular_retro * iridescenceFresnel_metallic, materialInfo.iridescenceFactor);
+    f_dielectric_brdf_retro = mix(f_dielectric_brdf_retro, rgb_mix(f_diffuse, f_specular_retro, iridescenceFresnel_dielectric), materialInfo.iridescenceFactor);
+#endif
+
+    f_metal_brdf_ibl = mix(f_metal_brdf_ibl, f_metal_brdf_retro, materialInfo.retroreflectionFactor);
+    f_dielectric_brdf_ibl = mix(f_dielectric_brdf_ibl, f_dielectric_brdf_retro, materialInfo.retroreflectionFactor);
 #endif
 
 
@@ -348,6 +383,35 @@ void main()
 #ifdef MATERIAL_IRIDESCENCE
         l_metal_brdf = mix(l_metal_brdf, l_specular_metal * iridescenceFresnel_metallic, materialInfo.iridescenceFactor);
         l_dielectric_brdf = mix(l_dielectric_brdf, rgb_mix(l_diffuse, l_specular_dielectric, iridescenceFresnel_dielectric), materialInfo.iridescenceFactor);
+#endif
+
+#ifdef MATERIAL_RETROREFLECTION
+        // NdotV_retro == NdotV, so only the half vector (and thus NdotH/VdotH) needs
+        // recomputing for the retroreflective specular lobe. Anisotropy and iridescence are
+        // re-applied with v_retro/h_retro so they compose correctly with retroreflection
+        // instead of being silently dropped from the retro lobe.
+        vec3 h_retro = normalize(l + v_retro);
+        float NdotH_retro = clampedDot(n, h_retro);
+        float VdotH_retro = clampedDot(v_retro, h_retro);
+
+        vec3 dielectric_fresnel_retro = F_Schlick(materialInfo.f0_dielectric * materialInfo.specularWeight, materialInfo.f90_dielectric, abs(VdotH_retro));
+        vec3 metal_fresnel_retro = F_Schlick(baseColor.rgb, vec3(1.0), abs(VdotH_retro));
+
+#ifdef MATERIAL_ANISOTROPY
+        vec3 l_specular_retro = intensity * NdotL * BRDF_specularGGXAnisotropy(materialInfo.alphaRoughness, materialInfo.anisotropyStrength, n, v_retro, l, h_retro, materialInfo.anisotropicT, materialInfo.anisotropicB);
+#else
+        vec3 l_specular_retro = intensity * NdotL * BRDF_specularGGX(materialInfo.alphaRoughness, NdotL, NdotV, NdotH_retro);
+#endif
+        vec3 l_metal_brdf_retro = metal_fresnel_retro * l_specular_retro;
+        vec3 l_dielectric_brdf_retro = mix(l_diffuse, l_specular_retro, dielectric_fresnel_retro);
+
+#ifdef MATERIAL_IRIDESCENCE
+        l_metal_brdf_retro = mix(l_metal_brdf_retro, l_specular_retro * iridescenceFresnel_metallic, materialInfo.iridescenceFactor);
+        l_dielectric_brdf_retro = mix(l_dielectric_brdf_retro, rgb_mix(l_diffuse, l_specular_retro, iridescenceFresnel_dielectric), materialInfo.iridescenceFactor);
+#endif
+
+        l_metal_brdf = mix(l_metal_brdf, l_metal_brdf_retro, materialInfo.retroreflectionFactor);
+        l_dielectric_brdf = mix(l_dielectric_brdf, l_dielectric_brdf_retro, materialInfo.retroreflectionFactor);
 #endif
 
 #ifdef MATERIAL_CLEARCOAT
@@ -524,6 +588,13 @@ vec3 specularTexture = vec3(1.0);
 #endif
 #if DEBUG == DEBUG_IRIDESCENCE_THICKNESS
     g_finalColor.rgb = vec3(materialInfo.iridescenceThickness / 1200.0);
+#endif
+#endif
+
+    // Retroreflection:
+#ifdef MATERIAL_RETROREFLECTION
+#if DEBUG == DEBUG_RETROREFLECTION_FACTOR
+    g_finalColor.rgb = vec3(materialInfo.retroreflectionFactor);
 #endif
 #endif
 

--- a/source/Renderer/shaders/textures.glsl
+++ b/source/Renderer/shaders/textures.glsl
@@ -353,6 +353,28 @@ vec2 getIridescenceThicknessUV()
 #endif
 
 
+// Retroreflection
+
+
+#ifdef MATERIAL_RETROREFLECTION
+
+uniform sampler2D u_RetroreflectionSampler;
+uniform int u_RetroreflectionUVSet;
+uniform mat3 u_RetroreflectionUVTransform;
+
+
+vec2 getRetroreflectionUV()
+{
+    vec3 uv = vec3(u_RetroreflectionUVSet < 1 ? v_texcoord_0 : v_texcoord_1, 1.0);
+#ifdef HAS_RETROREFLECTION_UV_TRANSFORM
+    uv = u_RetroreflectionUVTransform * uv;
+#endif
+    return uv.xy;
+}
+
+#endif
+
+
 // Diffuse Transmission
 
 #ifdef MATERIAL_DIFFUSE_TRANSMISSION

--- a/source/gltf/gltf.js
+++ b/source/gltf/gltf.js
@@ -39,6 +39,7 @@ const allowedExtensions = [
     "KHR_materials_ior",
     "KHR_materials_iridescence",
     "KHR_materials_pbrSpecularGlossiness",
+    "KHR_materials_retroreflection",
     "KHR_materials_sheen",
     "KHR_materials_specular",
     "KHR_materials_transmission",

--- a/source/gltf/material.js
+++ b/source/gltf/material.js
@@ -33,6 +33,7 @@ class gltfMaterial extends GltfObject {
         this.hasIridescence = false;
         this.hasAnisotropy = false;
         this.hasDispersion = false;
+        this.hasRetroreflection = false;
 
         // non gltf properties
         this.type = "unlit";
@@ -105,6 +106,12 @@ class gltfMaterial extends GltfObject {
         }
         if (this.hasDispersion && renderingParameters.enabledExtensions.KHR_materials_dispersion) {
             defines.push("MATERIAL_DISPERSION 1");
+        }
+        if (
+            this.hasRetroreflection &&
+            renderingParameters.enabledExtensions.KHR_materials_retroreflection
+        ) {
+            defines.push("MATERIAL_RETROREFLECTION 1");
         }
 
         return defines;
@@ -482,6 +489,22 @@ class gltfMaterial extends GltfObject {
             if (this.extensions.KHR_materials_dispersion !== undefined) {
                 this.hasDispersion = true;
             }
+
+            // KHR Extension: Retroreflection
+            // See https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_retroreflection
+            if (this.extensions.KHR_materials_retroreflection !== undefined) {
+                this.hasRetroreflection = true;
+
+                const retroreflectionTexture =
+                    this.extensions.KHR_materials_retroreflection.retroreflectionTexture;
+
+                if (retroreflectionTexture !== undefined) {
+                    retroreflectionTexture.samplerName = "u_RetroreflectionSampler";
+                    this.parseTextureInfoExtensions(retroreflectionTexture, "Retroreflection");
+                    this.textures.push(retroreflectionTexture);
+                    this.defines.push("HAS_RETROREFLECTION_MAP 1");
+                }
+            }
         }
 
         initGlForMembers(this, gltf, webGlContext);
@@ -686,6 +709,13 @@ class gltfMaterial extends GltfObject {
             this.extensions.KHR_materials_ior = new KHR_materials_ior();
             this.extensions.KHR_materials_ior.fromJson(jsonExtensions.KHR_materials_ior);
         }
+
+        if (jsonExtensions.KHR_materials_retroreflection !== undefined) {
+            this.extensions.KHR_materials_retroreflection = new KHR_materials_retroreflection();
+            this.extensions.KHR_materials_retroreflection.fromJson(
+                jsonExtensions.KHR_materials_retroreflection
+            );
+        }
     }
 }
 
@@ -821,6 +851,24 @@ class KHR_materials_iridescence extends GltfObject {
             const iridescenceThicknessTexture = new gltfTextureInfo();
             iridescenceThicknessTexture.fromJson(jsonIridescence.iridescenceThicknessTexture);
             this.iridescenceThicknessTexture = iridescenceThicknessTexture;
+        }
+    }
+}
+
+class KHR_materials_retroreflection extends GltfObject {
+    static animatedProperties = ["retroreflectionFactor"];
+    constructor() {
+        super();
+        this.retroreflectionFactor = 0;
+        this.retroreflectionTexture = undefined;
+    }
+
+    fromJson(jsonRetroreflection) {
+        super.fromJson(jsonRetroreflection);
+        if (jsonRetroreflection.retroreflectionTexture !== undefined) {
+            const retroreflectionTexture = new gltfTextureInfo();
+            retroreflectionTexture.fromJson(jsonRetroreflection.retroreflectionTexture);
+            this.retroreflectionTexture = retroreflectionTexture;
         }
     }
 }


### PR DESCRIPTION

<img width="2560" height="1271" alt="trafficCone_KhrViewer" src="https://github.com/user-attachments/assets/74cf46a6-0c57-458d-b0c9-33d3bfa65a43" />

## Summary

Implements [`KHR_materials_retroreflection`](https://github.com/KhronosGroup/glTF/pull/2610), based on the Minimal Retroreflective Microfacet (MRM) model (Portsmouth et al., JCGT 15(1), 2026).

- Substitutes the view direction with its reflection about the normal (`V_retro = reflect(-V, N)`) before evaluating the metallic and dielectric BRDFs, then linearly blends the result with the regular BRDF by `retroreflectionFactor`.
- Applied to both the IBL path (`getIBLRadianceGGXRetroreflection` in `ibl.glsl`) and the punctual-light path (`pbr.frag`).
- Adds `KHR_materials_retroreflection` material extension parsing (`retroreflectionFactor`, `retroreflectionTexture`), the `MATERIAL_RETROREFLECTION` shader define, and a `Retroreflection Strength` debug output channel.

A companion PR to [glTF-Sample-Viewer](https://github.com/KhronosGroup/glTF-Sample-Viewer) adds the corresponding "Retroreflection" UI toggle and bumps this submodule pointer, and references [glTF-Sample-Viewer#664](https://github.com/KhronosGroup/glTF-Sample-Viewer/issues/664).

## Test plan

- [x] `npm run build` succeeds with no shader compile errors
- [x] Loaded the [glTF-Sample-Assets#285](https://github.com/KhronosGroup/glTF-Sample-Assets/pull/285) traffic cone test asset (retroreflective sleeve using `retroreflectionFactor: 1.0`, masked by `retroreflectionTexture`) — the retroreflective stripe reads noticeably brighter than the plain reflective stripe when camera and light are closely aligned, matching the extension's reference behavior